### PR TITLE
AUTHLIB-159: Tooling to automate release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,13 @@
 ---
 name: build
 on:
-  pull_request:
+  push:
     branches:
       - '**'
+  pull_request:
+    types:
+      - opened
+      - edited
   workflow_dispatch:
 
 jobs:
@@ -26,8 +30,3 @@ jobs:
       - name: Build with Maven
         run: mvn package
 
-      - name: Upload jar file
-        uses: actions/upload-artifact@v3
-        with:
-          name: authentication_lib.jar
-          path: target/authentication_lib.jar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,9 @@
 ---
 name: build
 on:
-  push:
+  pull_request:
     branches:
-      - main
-    tags:
-      - v*.*.*
+      - '**'
   workflow_dispatch:
 
 jobs:
@@ -26,57 +24,10 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn package -DskipTests
+        run: mvn package
 
       - name: Upload jar file
         uses: actions/upload-artifact@v3
         with:
           name: authentication_lib.jar
           path: target/authentication_lib.jar
-
-  build-image:
-    name: build Docker image
-    needs: build-java-source
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{github.repository}}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Log into container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Image metadata
-        id: image_metadata
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Download jar file
-        uses: actions/download-artifact@v3
-        with:
-          name: authentication_lib.jar
-          path: target
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          context: .
-          tags: ${{ steps.image_metadata.outputs.tags }}
-          labels: ${{ steps.image_metadata.outputs.labels }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,82 @@
+---
+name: build
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*.*.*
+  workflow_dispatch:
+
+jobs:
+  build-java-source:
+    name: build jar file
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java build environmant
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn package -DskipTests
+
+      - name: Upload jar file
+        uses: actions/upload-artifact@v3
+        with:
+          name: authentication_lib.jar
+          path: target/authentication_lib.jar
+
+  build-image:
+    name: build Docker image
+    needs: build-java-source
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{github.repository}}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: image_metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Download jar file
+        uses: actions/download-artifact@v3
+        with:
+          name: authentication_lib.jar
+          path: target
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.image_metadata.outputs.tags }}
+          labels: ${{ steps.image_metadata.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Release draft creation
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: get latest release with tag
+      id: latestrelease
+      run: |
+          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/OCTRI/authentication-lib/releases/latest | jq '.tag_name' | sed 's/\"//g')"
+    
+    - name: confirm release tag
+      run: |
+          echo ${{ steps.latestrelease.outputs.releasetag }}
+    
+    - name: tagcheckout
+      uses: actions/checkout@v3
+      with:
+          ref: ${{ steps.latestrelease.outputs.releasetag }}
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github
+
+    - name: Build with Maven
+      run: mvn package -DskipTests
+    
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -DskipTests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,6 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         server-id: github
-
-    - name: Build with Maven
-      run: mvn package -DskipTests
     
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -27,4 +27,26 @@
 		<module>authentication_lib</module>
 		<module>authentication_ui_bootstrap5</module>
 	</modules>
+
+	<distributionManagement>
+    	<repository>
+        	<id>github</id>
+        	<name>GitHub Packages</name>
+        	<url>https://maven.pkg.github.com/OCTRI/authentication-lib</url>
+    	</repository>
+	</distributionManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+				<configuration>
+					<altDeploymentRepository>github::default::https://maven.pkg.github.com/OCTRI/authentication-lib</altDeploymentRepository>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,18 +35,4 @@
         	<url>https://maven.pkg.github.com/OCTRI/authentication-lib</url>
     	</repository>
 	</distributionManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>github::default::https://maven.pkg.github.com/OCTRI/authentication-lib</altDeploymentRepository>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>


### PR DESCRIPTION
# Overview

Added manifests for automate build and release

## Issues

AUTHLIB-159

## Discussion

- Added `.github/workflows/build.yaml` to launch a build workflow on a push even ton the main branch, for any version tag
- Added `.github/workflows/release.yaml` to set appropriate release tag and build and publish the package to GitHub Packages
- Added `distributionManagement` to `pom.xml` to publish to GitHub Packages, and added `maven-deploy-plugin` to automate upload and distribute to GitHub Packages
