### PR TITLE
AUTHLIB-154: Remove global table styling.

### DIFF
--- a/authentication_ui_bootstrap5/src/main/resources/static/assets/css/authlib.css
+++ b/authentication_ui_bootstrap5/src/main/resources/static/assets/css/authlib.css
@@ -3,7 +3,7 @@ body.authlib {
 	padding-top:4rem;
 }
 
-.authlib-user-list .center-all td,th{
+.authlib-user-list .center-all td, .authlib-user-list .center-all th{
 	text-align :center;
 }
 


### PR DESCRIPTION
# Overview

Fixes the table styling for the authlib user list so it doesn't impact all th elements globally. This was causing table headers in managed content to be centered.

## Issues

AUTHLIB-154