### PR TITLE
CIS-3192 Add POM Metadata for Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [unreleased]
+
+### Changed
+
+- Enable Dependabot updates to Maven and GitHub Actions dependencies.
+- Add POM metadata required for publishing to Maven Central. (CIS-3192)
 
 ## [2.1.2] - 2024-12-20
 

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -7,13 +7,36 @@
 	<packaging>jar</packaging>
 
 	<name>authentication_lib</name>
-	<description>Library for Spring Security LDAP and Table-Based Authentication</description>
+	<description>OCTRI library for Spring Security LDAP and table-based authentication</description>
+	<url>https://github.com/OCTRI/authentication-lib</url>
 
 	<parent>
 		<groupId>org.octri.authentication</groupId>
 		<artifactId>authentication_lib_parent</artifactId>
 		<version>2.1.3-SNAPSHOT</version>
 	</parent>
+
+	<licenses>
+		<license>
+			<name>The 3-Clause BSD License</name>
+			<url>https://opensource.org/license/bsd-3-clause</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>OCTRI Innovation Core</name>
+			<email>criapps@ohsu.edu</email>
+			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
+			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:https://github.com/OCTRI/authentication-lib.git</connection>
+		<developerConnection>scm:git:https://github.com/OCTRI/authentication-lib.git</developerConnection>
+		<url>https://github.com/OCTRI/authentication-lib/tree/main</url>
+	</scm>
 
 	<properties>
 		<java.version>17</java.version>

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -26,7 +26,7 @@
 	<developers>
 		<developer>
 			<name>OCTRI Innovation Core</name>
-			<email>criapps@ohsu.edu</email>
+			<email>octri-devops@ohsu.edu</email>
 			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
 			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
 		</developer>

--- a/authentication_ui_bootstrap5/pom.xml
+++ b/authentication_ui_bootstrap5/pom.xml
@@ -7,13 +7,36 @@
 	<packaging>jar</packaging>
 
 	<name>authentication_ui_bootstrap5</name>
-	<description>Authentication UI Templates for Bootstrap 5</description>
+	<description>OCTRI Authentication UI templates for Bootstrap 5</description>
+	<url>https://github.com/OCTRI/authentication-lib</url>
 
 	<parent>
 		<groupId>org.octri.authentication</groupId>
 		<artifactId>authentication_lib_parent</artifactId>
 		<version>2.1.3-SNAPSHOT</version>
 	</parent>
+
+	<licenses>
+		<license>
+			<name>The 3-Clause BSD License</name>
+			<url>https://opensource.org/license/bsd-3-clause</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>OCTRI Innovation Core</name>
+			<email>criapps@ohsu.edu</email>
+			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
+			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:https://github.com/OCTRI/authentication-lib.git</connection>
+		<developerConnection>scm:git:https://github.com/OCTRI/authentication-lib.git</developerConnection>
+		<url>https://github.com/OCTRI/authentication-lib/tree/main</url>
+	</scm>
 
 	<properties>
 		<java.version>17</java.version>
@@ -62,6 +85,9 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/authentication_ui_bootstrap5/pom.xml
+++ b/authentication_ui_bootstrap5/pom.xml
@@ -26,7 +26,7 @@
 	<developers>
 		<developer>
 			<name>OCTRI Innovation Core</name>
-			<email>criapps@ohsu.edu</email>
+			<email>octri-devops@ohsu.edu</email>
 			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
 			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
 		</developer>

--- a/authentication_ui_bootstrap5/pom.xml
+++ b/authentication_ui_bootstrap5/pom.xml
@@ -85,9 +85,6 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<developers>
 		<developer>
 			<name>OCTRI Innovation Core</name>
-			<email>criapps@ohsu.edu</email>
+			<email>octri-devops@ohsu.edu</email>
 			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
 			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
 		</developer>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,9 @@
 	<version>2.1.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<name>authentication_parent</name>
-	<description>Library for Spring Security Authentication</description>
+	<name>authentication_lib_parent</name>
+	<description>OCTRI parent library for Spring Security authentication</description>
+	<url>https://github.com/OCTRI/authentication-lib</url>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -16,6 +17,28 @@
 		<version>3.2.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
+
+	<licenses>
+		<license>
+			<name>The 3-Clause BSD License</name>
+			<url>https://opensource.org/license/bsd-3-clause</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>OCTRI Innovation Core</name>
+			<email>criapps@ohsu.edu</email>
+			<organization>Oregon Clinical &amp; Translational Research Institute (OCTRI)</organization>
+			<organizationUrl>https://www.ohsu.edu/octri</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:https://github.com/OCTRI/authentication-lib.git</connection>
+		<developerConnection>scm:git:https://github.com/OCTRI/authentication-lib.git</developerConnection>
+		<url>https://github.com/OCTRI/authentication-lib/tree/main</url>
+	</scm>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,10 +52,10 @@
 	</modules>
 
 	<distributionManagement>
-    	<repository>
-        	<id>github</id>
-        	<name>GitHub Packages</name>
-        	<url>https://maven.pkg.github.com/OCTRI/authentication-lib</url>
-    	</repository>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/OCTRI/authentication-lib</url>
+		</repository>
 	</distributionManagement>
 </project>


### PR DESCRIPTION
# Overview

Add POM metadata required for publishing to Maven Central.

Documentation: https://central.sonatype.org/publish/requirements/#required-pom-metadata

## Issues

[CIS-3192](https://jirabp.ohsu.edu/browse/CIS-3192)

[X] Added to CHANGELOG.md
