### PR TITLE
CIS-3193 Javadoc Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable Dependabot updates to Maven and GitHub Actions dependencies.
 - Add POM metadata required for publishing to Maven Central. (CIS-3192)
+- Enable building Javadoc and source jars and fix Javadoc issues. (CIS-3193)
 
 ## [2.1.2] - 2024-12-20
 

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -144,6 +144,9 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>
@@ -153,6 +156,9 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/authentication_lib/src/main/java/org/octri/authentication/DefaultSecurityConfigurer.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/DefaultSecurityConfigurer.java
@@ -44,6 +44,9 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+/**
+ * Provides default security configuration to consuming applications.
+ */
 @EnableMethodSecurity
 @EnableAspectJAutoProxy
 @PropertySource("classpath:authlib.properties")
@@ -120,8 +123,10 @@ public class DefaultSecurityConfigurer {
 	 * the default filter chain is configured by other public methods in this class.
 	 *
 	 * @param http
-	 * @return
+	 *            security configuration builder
+	 * @return security filter chain constructed using the library's default values
 	 * @throws Exception
+	 *             if an error occurred when constructing the filter chain
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -150,8 +155,8 @@ public class DefaultSecurityConfigurer {
 	 * Provides a default {@link HttpSessionEventPublisher} bean if the application does not provide a custom one. This
 	 * ensures that Spring Security publishes events used to record when sessions are destroyed.
 	 *
-	 * @see {@link SessionDestroyedListener}
-	 * @return
+	 * @see SessionDestroyedListener
+	 * @return the default session event publisher
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -162,7 +167,7 @@ public class DefaultSecurityConfigurer {
 	/**
 	 * Provides a set containing the enabled authentication methods to simplify lookup and for use in the UI.
 	 *
-	 * @return
+	 * @return the set of enabled authentication methods
 	 */
 	@Bean
 	public Set<AuthenticationMethod> enabledAuthenticationMethods() {
@@ -187,7 +192,9 @@ public class DefaultSecurityConfigurer {
 	 * Adds providers for all enabled authentication methods to the authentication manager builder.
 	 *
 	 * @param authBuilder
+	 *            the authentication manager builder to modify
 	 * @throws Exception
+	 *             if an error occurs when configuring the authentication manager
 	 * @see configureSamlWithDefaults
 	 */
 	public void configureAuthenticationManager(AuthenticationManagerBuilder authBuilder)
@@ -207,7 +214,9 @@ public class DefaultSecurityConfigurer {
 	 * Adds support for SAML authentication to the authentication manager.
 	 *
 	 * @param authBuilder
+	 *            the authentication manager builder to modify
 	 * @throws Exception
+	 *             if an error occurs when configuring SAML authentication
 	 */
 	public void configureAuthenticationManagerForSaml(AuthenticationManagerBuilder authBuilder) throws Exception {
 		if (samlEnabled()) {
@@ -222,7 +231,9 @@ public class DefaultSecurityConfigurer {
 	 * Adds support for table-based authentication to the authentication manager.
 	 *
 	 * @param authBuilder
+	 *            the authentication manger builder to modify
 	 * @throws Exception
+	 *             if an error occurs when configuring table-based authentication
 	 */
 	public void configureAuthenticationManagerForTableBased(AuthenticationManagerBuilder authBuilder)
 			throws Exception {
@@ -239,7 +250,9 @@ public class DefaultSecurityConfigurer {
 	 * Adds support for LDAP authentication to the authentication manager.
 	 *
 	 * @param authBuilder
+	 *            the authentication manager builder to modify
 	 * @throws Exception
+	 *             if an error occurs when configuring LDAP authentication
 	 */
 	public void configureAuthenticationManagerForLdap(AuthenticationManagerBuilder authBuilder) throws Exception {
 		if (ldapEnabled) {
@@ -271,8 +284,9 @@ public class DefaultSecurityConfigurer {
 	 * @param authManager
 	 *            the AuthenticationManager to user, e.g. from calling `AuthenticationManagerBuilder.build()`
 	 * @throws Exception
-	 * @see {@link SamlProperties}
-	 * @see {@link SamlAuthenticationConfiguration}
+	 *             if an error occurs when configuring SAML authentication
+	 * @see SamlProperties
+	 * @see SamlAuthenticationConfiguration
 	 */
 	public void configureSamlWithDefaults(HttpSecurity http, AuthenticationManager authManager) throws Exception {
 		if (!samlEnabled()) {
@@ -306,10 +320,12 @@ public class DefaultSecurityConfigurer {
 	 * metadata is updated, and the user is redirected to the login failure URL.
 	 *
 	 * @param http
+	 *            HttpSecurity builder
 	 * @throws Exception
-	 * @see {@link ApplicationRouteProperties}
-	 * @see {@link ApplicationAuthenticationSuccessHandler}
-	 * @see {@link ApplicationAuthenticationFailureHandler}
+	 *             if an error occurs when configuring form login support
+	 * @see AuthenticationRouteProperties
+	 * @see ApplicationAuthenticationSuccessHandler
+	 * @see ApplicationAuthenticationFailureHandler
 	 */
 	public void configureFormLoginWithDefaults(HttpSecurity http) throws Exception {
 		formAuthSuccessHandler.setDefaultTargetUrl(routes.getDefaultLoginSuccessUrl());
@@ -326,8 +342,10 @@ public class DefaultSecurityConfigurer {
 	 * the logout success URL.
 	 *
 	 * @param http
+	 *            HttpSecurity builder
 	 * @throws Exception
-	 * @see {@link ApplicationRouteProperties}
+	 *             if an error occurs when configuring logout behavior
+	 * @see AuthenticationRouteProperties
 	 */
 	public void configureLogoutWithDefaults(HttpSecurity http) throws Exception {
 		http.logout(logout -> logout
@@ -337,7 +355,7 @@ public class DefaultSecurityConfigurer {
 	}
 
 	/**
-	 * Configures default route security. By default, public routes configured in {@link ApplicationRouteProperties}
+	 * Configures default route security. By default, public routes configured in {@link AuthenticationRouteProperties}
 	 * will allow anonymous access, and all other routes will require authentication. The HTTP PUT, POST, and PATCH
 	 * methods will require authentication, and HTTP DELETE will be denied.
 	 * <br>
@@ -345,8 +363,10 @@ public class DefaultSecurityConfigurer {
 	 * not be appropriate if you are implementing a custom filter chain.
 	 *
 	 * @param http
+	 *            HttpSecurity builder
 	 * @throws Exception
-	 * @see {@link ApplicationRouteProperties}
+	 *             if an error occurs when configuring default route security
+	 * @see AuthenticationRouteProperties
 	 */
 	public void configureRouteSecurityWithDefaults(HttpSecurity http) throws Exception {
 		http.authorizeHttpRequests(auth -> auth.requestMatchers(routes.getPublicRoutesWithDefaults())
@@ -363,8 +383,10 @@ public class DefaultSecurityConfigurer {
 	 * Configures the content security policy (CSP) header if CSP is enabled.
 	 *
 	 * @param http
+	 *            HttpSecurity builder
 	 * @throws Exception
-	 * @see {@link ContentSecurityPolicyProperties}
+	 *             if an error occurs when configuring content security policy
+	 * @see ContentSecurityPolicyProperties
 	 */
 	public void configureContentSecurityPolicy(HttpSecurity http) throws Exception {
 		if (cspProperties == null || !cspProperties.isEnabled()) {

--- a/authentication_lib/src/main/java/org/octri/authentication/config/AuthenticationRouteProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/AuthenticationRouteProperties.java
@@ -14,8 +14,7 @@ public class AuthenticationRouteProperties {
 	/**
 	 * Default list of routes that do not require authentication.
 	 *
-	 * @see publicRoutes
-	 * @see getPublicRoutesWithDefaults
+	 * @see #getPublicRoutesWithDefaults
 	 */
 	public static final String[] DEFAULT_PUBLIC_ROUTES = new String[] {
 			"/",
@@ -68,50 +67,116 @@ public class AuthenticationRouteProperties {
 	 */
 	private String[] customPublicRoutes = new String[] {};
 
+	/**
+	 * Gets the configured {@link #loginUrl}.
+	 *
+	 * @return the configured login URL
+	 */
 	public String getLoginUrl() {
 		return loginUrl;
 	}
 
+	/**
+	 * Sets the URL of the login page.
+	 * 
+	 * @param loginUrl
+	 *            login form path
+	 */
 	public void setLoginUrl(String loginUrl) {
 		this.loginUrl = loginUrl;
 	}
 
+	/**
+	 * Gets the configured {@link #defaultLoginSuccessUrl}.
+	 *
+	 * @return the configured login success URL
+	 */
 	public String getDefaultLoginSuccessUrl() {
 		return defaultLoginSuccessUrl;
 	}
 
+	/**
+	 * Sets the default URL the user will be sent to after login.
+	 *
+	 * @param defaultLoginSuccessUrl
+	 *            default post-login URL path
+	 */
 	public void setDefaultLoginSuccessUrl(String defaultLoginSuccessUrl) {
 		this.defaultLoginSuccessUrl = defaultLoginSuccessUrl;
 	}
 
+	/**
+	 * Gets the configured {@link #loginFailureRedirectUrl}.
+	 *
+	 * @return the configured login failure redirect URL
+	 */
 	public String getLoginFailureRedirectUrl() {
 		return loginFailureRedirectUrl;
 	}
 
+	/**
+	 * Sets the URL the user will be sent to if their login is unsuccessful.
+	 *
+	 * @param loginFailureRedirectUrl
+	 *            the URL after unsuccessful login
+	 */
 	public void setLoginFailureRedirectUrl(String loginFailureRedirectUrl) {
 		this.loginFailureRedirectUrl = loginFailureRedirectUrl;
 	}
 
+	/**
+	 * Gets the configured {@link #logoutUrl}.
+	 *
+	 * @return the configured logout URL
+	 */
 	public String getLogoutUrl() {
 		return logoutUrl;
 	}
 
+	/**
+	 * Sets the URL of the logout form.
+	 *
+	 * @param logoutUrl
+	 *            logout URL path
+	 */
 	public void setLogoutUrl(String logoutUrl) {
 		this.logoutUrl = logoutUrl;
 	}
 
+	/**
+	 * Gets the configured {@link #logoutSuccessUrl}.
+	 *
+	 * @return the configured logout success URL
+	 */
 	public String getLogoutSuccessUrl() {
 		return logoutSuccessUrl;
 	}
 
+	/**
+	 * Sets the URL displayed after the user logs out.
+	 *
+	 * @param logoutSuccessUrl
+	 *            post-logout URL path
+	 */
 	public void setLogoutSuccessUrl(String logoutSuccessUrl) {
 		this.logoutSuccessUrl = logoutSuccessUrl;
 	}
 
+	/**
+	 * Gets the list of custom routes that do not require authentication.
+	 *
+	 * @return array of route pattern strings
+	 */
 	public String[] getCustomPublicRoutes() {
 		return customPublicRoutes;
 	}
 
+	/**
+	 * Sets the list of custom routes that will do not require authentication.
+	 *
+	 * @param customPublicRoutes
+	 *            array of route pattern strings
+	 */
 	public void setCustomPublicRoutes(String[] customPublicRoutes) {
 		this.customPublicRoutes = customPublicRoutes;
 	}
@@ -119,7 +184,7 @@ public class AuthenticationRouteProperties {
 	/**
 	 * Convenience method that gets the configured public application routes concatenated with the default public
 	 * routes.
-	 * 
+	 *
 	 * @return array containing the default public routes, plus any custom public routes
 	 */
 	public String[] getPublicRoutesWithDefaults() {

--- a/authentication_lib/src/main/java/org/octri/authentication/config/ContentSecurityPolicyProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/ContentSecurityPolicyProperties.java
@@ -5,15 +5,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration properties for content security policy (CSP).
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+ * @see <a href=
+ *      "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP">https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP</a>
  */
 @ConfigurationProperties(prefix = "octri.authentication.csp")
 public class ContentSecurityPolicyProperties {
 
+	/**
+	 * The default content security policy. Allows resources from the same origin as the page, and images from the same
+	 * origin or inline data: URLs.
+	 */
 	public static final String DEFAULT_POLICY = "default-src 'self'; img-src 'self' data:";
 
 	/**
-	 * Whether to enable the `Content-Security-Policy` header. Default: false.
+	 * Whether to enable the <code>Content-Security-Policy</code> header. Default: false.
 	 */
 	private boolean enabled = false;
 
@@ -28,26 +33,59 @@ public class ContentSecurityPolicyProperties {
 	 */
 	private String policy = DEFAULT_POLICY;
 
+	/**
+	 * Gets whether the <code>Content-Security-Policy</code> header is enabled.
+	 * 
+	 * @return whether the CSP header is enabled
+	 */
 	public boolean isEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Sets whether to enable the <code>Content-Security-Policy</code> header.
+	 * 
+	 * @param enabled
+	 *            true to enable the header, false otherwise
+	 */
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets whether the configured policy is enforced, or if policy violations are only logged.
+	 * 
+	 * @return whether CSP policy is enforced
+	 */
 	public boolean isEnforced() {
 		return enforced;
 	}
 
+	/**
+	 * Sets whether to enforce the policy, or if policy violations should only be logged.
+	 * 
+	 * @param enforced
+	 *            true to enforce the policy, false to log only
+	 */
 	public void setEnforced(boolean enforced) {
 		this.enforced = enforced;
 	}
 
+	/**
+	 * Gets the configured policy string.
+	 * 
+	 * @return value of the current policy
+	 */
 	public String getPolicy() {
 		return policy;
 	}
 
+	/**
+	 * Set the content security policy string.
+	 * 
+	 * @param policy
+	 *            the policy to set
+	 */
 	public void setPolicy(String policy) {
 		this.policy = policy;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/EmailConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/EmailConfiguration.java
@@ -22,74 +22,173 @@ public class EmailConfiguration {
 	private String username;
 	private String password;
 
+	/**
+	 * Gets whether email support is enabled.
+	 * 
+	 * @return true if email is enabled
+	 */
 	public Boolean getEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Sets whether to enable email support
+	 *
+	 * @param enabled
+	 *            true to enable email support, false to disable it
+	 */
 	public void setEnabled(Boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets the configured from email address.
+	 * 
+	 * @return the configured from email address
+	 */
 	public String getFrom() {
 		return from;
 	}
 
+	/**
+	 * Sets the from email address that messages will come from.
+	 * 
+	 * @param from
+	 *            the from email address
+	 */
 	public void setFrom(String from) {
 		this.from = from;
 	}
 
+	/**
+	 * Gets the configured default MimeMessage character encoding.
+	 * 
+	 * @return the configured MimeMessage character encoding
+	 */
 	public String getDefaultEncoding() {
 		return defaultEncoding;
 	}
 
+	/**
+	 * Sets the default MimeMessage encoding.
+	 * 
+	 * @param defaultEncoding
+	 *            the default MimeMessage character encoding
+	 */
 	public void setDefaultEncoding(String defaultEncoding) {
 		this.defaultEncoding = defaultEncoding;
 	}
 
+	/**
+	 * Gets the configured mail server host.
+	 * 
+	 * @return the configured mail server host
+	 */
 	public String getHost() {
 		return host;
 	}
 
+	/**
+	 * Sets the mail server host.
+	 * 
+	 * @param host
+	 *            mail server host
+	 */
 	public void setHost(String host) {
 		this.host = host;
 	}
 
+	/**
+	 * Gets the configured mail server port.
+	 * 
+	 * @return the configure mail port
+	 */
 	public Integer getPort() {
 		return port;
 	}
 
+	/**
+	 * Sets the mail server port.
+	 * 
+	 * @param port
+	 *            the mail server port
+	 */
 	public void setPort(Integer port) {
 		this.port = port;
 	}
 
+	/**
+	 * Gets the configured protocol used by the mail server.
+	 * 
+	 * @return the configured mail server protocol
+	 */
 	public String getProtocol() {
 		return protocol;
 	}
 
+	/**
+	 * Sets the protocol used by the mail server.
+	 * 
+	 * @param protocol
+	 *            the mail server protocol.
+	 */
 	public void setProtocol(String protocol) {
 		this.protocol = protocol;
 	}
 
+	/**
+	 * Gets whether connection to the mail server is checked at startup.
+	 * 
+	 * @return true if the connection is tested
+	 */
 	public String getTestConnection() {
 		return testConnection;
 	}
 
+	/**
+	 * Sets whether to test the connection to the mail server at startup.
+	 *
+	 * @param testConnection
+	 *            true if the connection should be tested, false if not
+	 */
 	public void setTestConnection(String testConnection) {
 		this.testConnection = testConnection;
 	}
 
+	/**
+	 * Gets the username used when connecting to the mail server.
+	 * 
+	 * @return mail server username
+	 */
 	public String getUsername() {
 		return username;
 	}
 
+	/**
+	 * Sets the username used when connecting to the mail server.
+	 * 
+	 * @param username
+	 *            mail server username
+	 */
 	public void setUsername(String username) {
 		this.username = username;
 	}
 
+	/**
+	 * Gets the password used when connecting to the mail server.
+	 * 
+	 * @return the mail server password
+	 */
 	public String getPassword() {
 		return password;
 	}
 
+	/**
+	 * Sets the password to use when connecting to the mail server.
+	 * 
+	 * @param password
+	 *            the mail server password
+	 */
 	public void setPassword(String password) {
 		this.password = password;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/LdapAuthenticationConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/LdapAuthenticationConfiguration.java
@@ -24,6 +24,12 @@ public class LdapAuthenticationConfiguration {
 
 	private LdapContextProperties ldapContextProperties;
 
+	/**
+	 * Constructor
+	 *
+	 * @param ldapContextProperties
+	 *            LDAP configuration properties
+	 */
 	public LdapAuthenticationConfiguration(LdapContextProperties ldapContextProperties) {
 		this.ldapContextProperties = ldapContextProperties;
 	}
@@ -31,7 +37,7 @@ public class LdapAuthenticationConfiguration {
 	/**
 	 * Provides context configuration properties for LDAP authentication.
 	 *
-	 * @return
+	 * @return LDAP configuration properties
 	 */
 	@Bean
 	public LdapContextProperties ldapContextProperties() {
@@ -41,7 +47,7 @@ public class LdapAuthenticationConfiguration {
 	/**
 	 * Provides the configured LDAP organization name.
 	 *
-	 * @return
+	 * @return the configured LDAP organization name
 	 */
 	@Bean
 	public String ldapOrganization() {
@@ -54,7 +60,7 @@ public class LdapAuthenticationConfiguration {
 	 * NOTE: Bean must be of type {@link LdapContextSource} to prevent Spring Boot's autoconfiguration from providing a
 	 * conflicting bean.
 	 *
-	 * @return
+	 * @return default LDAP context source
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -70,7 +76,8 @@ public class LdapAuthenticationConfiguration {
 	 * Provides a default LDAP user search for LDAP authentication.
 	 *
 	 * @param ldapContextSource
-	 * @return
+	 *            LDAP context source
+	 * @return LDAP search filter for finding user accounts
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -83,7 +90,9 @@ public class LdapAuthenticationConfiguration {
 	 * Provides a default user details mapper for LDAP authentication. By default, user details are loaded from the
 	 * database instead of the LDAP directory, even for accounts authenticated using LDAP.
 	 *
-	 * @return
+	 * @param userDetailsService
+	 *            service used to look up database user details
+	 * @return default LDAP user details mapper
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -95,7 +104,7 @@ public class LdapAuthenticationConfiguration {
 	 * Provides a default authorities populator for LDAP authentication. By default, authorities granted to the user
 	 * are loaded from the database instead of the LDAP directory, even for accounts authenticated using LDAP.
 	 *
-	 * @return
+	 * @return default LDAP authorities populator
 	 */
 	@Bean
 	@ConditionalOnMissingBean

--- a/authentication_lib/src/main/java/org/octri/authentication/config/LdapContextProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/LdapContextProperties.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull;
 /**
  * Configuration properties for the LDAP context source.
  *
- * @see LdapAuthenticationConfiguration.java
+ * @see LdapAuthenticationConfiguration
  */
 @Validated
 @ConfigurationProperties(prefix = "ldap.context-source")
@@ -56,58 +56,135 @@ public class LdapContextProperties {
 	@NotNull
 	private String emailDomain;
 
+	/**
+	 * Gets the URL of the LDAP directory.
+	 * 
+	 * @return LDAP directory URL
+	 */
 	public String getUrl() {
 		return url;
 	}
 
+	/**
+	 * Sets the URL of the LDAP directory.
+	 * 
+	 * @param url
+	 *            LDAP directory URL
+	 */
 	public void setUrl(String url) {
 		this.url = url;
 	}
 
+	/**
+	 * Gets the user DN used to bind to the directory.
+	 * 
+	 * @return user DN
+	 */
 	public String getUserDn() {
 		return userDn;
 	}
 
+	/**
+	 * Sets the user DN used to bind to the directory.
+	 * 
+	 * @param userDn
+	 *            user DN
+	 */
 	public void setUserDn(String userDn) {
 		this.userDn = userDn;
 	}
 
+	/**
+	 * Gets the password used to bind to the directory.
+	 * 
+	 * @return the password
+	 */
 	public String getPassword() {
 		return password;
 	}
 
+	/**
+	 * Sets the password used to bind to the directory.
+	 * 
+	 * @param password
+	 *            the password to use
+	 */
 	public void setPassword(String password) {
 		this.password = password;
 	}
 
+	/**
+	 * Gets the base DN (subtree) searched for user accounts.
+	 * 
+	 * @return the base DN
+	 */
 	public String getSearchBase() {
 		return searchBase;
 	}
 
+	/**
+	 * Sets the base DN (subtree) searched for user accounts.
+	 * 
+	 * @param searchBase
+	 *            the base DN to search
+	 */
 	public void setSearchBase(String searchBase) {
 		this.searchBase = searchBase;
 	}
 
+	/**
+	 * Gets the filter used to search for user accounts.
+	 * 
+	 * @return user search filter
+	 */
 	public String getSearchFilter() {
 		return searchFilter;
 	}
 
+	/**
+	 * Sets the filter used to search for user accounts.
+	 * 
+	 * @param searchFilter
+	 *            user search filter
+	 */
 	public void setSearchFilter(String searchFilter) {
 		this.searchFilter = searchFilter;
 	}
 
+	/**
+	 * Gets the LDAP user organization used to populate the user's "institution" property.
+	 * 
+	 * @return the LDAP user organization
+	 */
 	public String getOrganization() {
 		return organization;
 	}
 
+	/**
+	 * Sets the LDAP user organization used to populate the user's "institution" property.
+	 * 
+	 * @param organization
+	 *            the LDAP user organization
+	 */
 	public void setOrganization(String organization) {
 		this.organization = organization;
 	}
 
+	/**
+	 * Gets the email domain used to identify LDAP accounts.
+	 * 
+	 * @return the LDAP email domain
+	 */
 	public String getEmailDomain() {
 		return emailDomain;
 	}
 
+	/**
+	 * Sets the email domain used to identify LDAP accounts.
+	 * 
+	 * @param emailDomain
+	 *            an email domain
+	 */
 	public void setEmailDomain(String emailDomain) {
 		this.emailDomain = emailDomain;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationConfiguration.java
@@ -38,6 +38,16 @@ public class OctriAuthenticationConfiguration {
 	private String contextPath;
 	private OctriAuthenticationProperties authenticationProperties;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param env
+	 *            the Spring application environment
+	 * @param authenticationProperties
+	 *            authentication configuration
+	 * @param contextPath
+	 *            the application context path (first URL path segment)
+	 */
 	public OctriAuthenticationConfiguration(Environment env, OctriAuthenticationProperties authenticationProperties,
 			@Value("${server.servlet.context-path:}") String contextPath) {
 		this.authenticationProperties = authenticationProperties;
@@ -48,25 +58,40 @@ public class OctriAuthenticationConfiguration {
 		validateRoleStyle();
 	}
 
+	/**
+	 * Whether LDAP authentication is enabled.
+	 *
+	 * @return true if LDAP authentication is enabled
+	 */
 	@Bean
 	public Boolean ldapEnabled() {
 		return authenticationProperties.getEnableLdap();
 	}
 
+	/**
+	 * Whether table-based authentication is enabled.
+	 *
+	 * @return true if table-based authentication is enabled
+	 */
 	@Bean
 	public Boolean tableBasedEnabled() {
 		return authenticationProperties.getEnableTableBased();
 	}
 
+	/**
+	 * Helper object used to construct the path to authentication-related URLs.
+	 *
+	 * @return the URL helper
+	 */
 	@Bean
-	public AuthenticationUrlHelper authenticatonUrlHelper() {
+	public AuthenticationUrlHelper authenticationUrlHelper() {
 		return new AuthenticationUrlHelper(authenticationProperties.getBaseUrl(), contextPath);
 	}
 
 	/**
 	 * Provides a default BCrypt password encoder unless overridden by the application.
 	 *
-	 * @return
+	 * @return default password encoder
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -77,6 +102,9 @@ public class OctriAuthenticationConfiguration {
 
 	/**
 	 * Throws an exception unless at least one authentication method has been enabled.
+	 *
+	 * @param env
+	 *            Spring application environment, used to look up property values
 	 */
 	private void validateAuthenticationMethods(Environment env) {
 		String errorMessage = "The authentication_lib requires at least one authentication method to be enabled. "

--- a/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationProperties.java
@@ -19,7 +19,20 @@ public class OctriAuthenticationProperties {
 	 * (may be either a plain username or an email adress).
 	 */
 	public static enum UsernameStyle {
-		PLAIN, EMAIL, MIXED
+		/**
+		 * Simple username style. May not be an email address.
+		 */
+		PLAIN,
+
+		/**
+		 * Username must be an email address.
+		 */
+		EMAIL,
+
+		/**
+		 * Username may be either a plain username or an email address.
+		 */
+		MIXED
 	}
 
 	/**
@@ -27,7 +40,20 @@ public class OctriAuthenticationProperties {
 	 * any number of roles), or CUSTOM (application-specific behavior).
 	 */
 	public static enum RoleStyle {
-		SINGLE, MULTIPLE, CUSTOM
+		/**
+		 * Users may only have one role.
+		 */
+		SINGLE,
+
+		/**
+		 * A user may have any number of roles.
+		 */
+		MULTIPLE,
+
+		/**
+		 * Role behavior is application-specific.
+		 */
+		CUSTOM
 	}
 
 	/**
@@ -35,7 +61,7 @@ public class OctriAuthenticationProperties {
 	 */
 	public static final String DEFAULT_BASE_URL = "http://localhost:8080";
 
-	/*
+	/**
 	 * The default value in minutes for "octri.authentication.password-token-validity"
 	 */
 	public static final Duration DEFAULT_PASSWORD_TOKEN_DURATION = Duration.ofMinutes(30);
@@ -69,7 +95,7 @@ public class OctriAuthenticationProperties {
 
 	/**
 	 * Style of usernames allowed. Valid options are PLAIN (simple username), EMAIL (must be an email address), or MIXED
-	 * (may be either a plain username or an email adress). Defaults to PLAIN.
+	 * (may be either a plain username or an email address). Defaults to PLAIN.
 	 */
 	private UsernameStyle usernameStyle = UsernameStyle.PLAIN;
 
@@ -103,90 +129,218 @@ public class OctriAuthenticationProperties {
 	 */
 	private String customRoleScript;
 
+	/**
+	 * Gets whether LDAP authentication is enabled.
+	 *
+	 * @return true if LDAP authentication is enabled, false if not
+	 */
 	public Boolean getEnableLdap() {
 		return enableLdap;
 	}
 
+	/**
+	 * Sets whether to enable LDAP authentication.
+	 *
+	 * @param enableLdap
+	 *            true to enable LDAP authentication, false if not
+	 */
 	public void setEnableLdap(Boolean enableLdap) {
 		this.enableLdap = enableLdap;
 	}
 
+	/**
+	 * Gets whether table-based authentication is enabled.
+	 *
+	 * @return true if table-based authentication is enabled, false if not
+	 */
 	public Boolean getEnableTableBased() {
 		return enableTableBased;
 	}
 
+	/**
+	 * Sets whether to enable table-based authentication.
+	 *
+	 * @param enableTableBased
+	 *            true to enable table-based authentication, false if not
+	 */
 	public void setEnableTableBased(Boolean enableTableBased) {
 		this.enableTableBased = enableTableBased;
 	}
 
+	/**
+	 * Gets the base URL of the application without a context path. Used to construct links sent in emails.
+	 *
+	 * @return the application's base URL
+	 */
 	public String getBaseUrl() {
 		return baseUrl;
 	}
 
+	/**
+	 * Sets the base URL of the application, including the host, port, and scheme. Does not include the context path.
+	 *
+	 * @param baseUrl
+	 *            the application's base URL
+	 */
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
 	}
 
+	/**
+	 * Gets the maximum number of failed login attempts before accounts are locked.
+	 *
+	 * @return the number of allowed login attempts
+	 */
 	public Integer getMaxLoginAttempts() {
 		return maxLoginAttempts;
 	}
 
+	/**
+	 * Gets the maximum number of failed login attempts before accounts are locked.
+	 *
+	 * @param maxLoginAttempts
+	 *            the number of login attempts to allow
+	 */
 	public void setMaxLoginAttempts(Integer maxLoginAttempts) {
 		this.maxLoginAttempts = maxLoginAttempts;
 	}
 
+	/**
+	 * Gets the length of time (in days) that table-based credentials are valid. After this period has elapsed, users
+	 * will be required to change their password.
+	 *
+	 * @return the number of days that table-based passwords will be valid
+	 */
 	public Integer getCredentialsExpirationPeriod() {
 		return credentialsExpirationPeriod;
 	}
 
+	/**
+	 * Sets the length of time (in days) that table-based credentials will be valid. After this period has elapsed,
+	 * users will be required to change their password.
+	 *
+	 * @param credentialsExpirationPeriod
+	 *            the number of days that table-based passwords should be valid
+	 */
 	public void setCredentialsExpirationPeriod(Integer credentialsExpirationPeriod) {
 		this.credentialsExpirationPeriod = credentialsExpirationPeriod;
 	}
 
+	/**
+	 * Gets the allowed username style.
+	 *
+	 * @see UsernameStyle
+	 * @return the type of usernames allowed
+	 */
 	public UsernameStyle getUsernameStyle() {
 		return usernameStyle;
 	}
 
+	/**
+	 * Sets the allowed username style.
+	 *
+	 * @see UsernameStyle
+	 * @param usernameStyle
+	 *            the type of usernames to allow
+	 */
 	public void setUsernameStyle(UsernameStyle usernameStyle) {
 		this.usernameStyle = usernameStyle;
 	}
 
+	/**
+	 * Sets the length of time that password reset tokens will be valid for.
+	 *
+	 * @param validityTime
+	 *            how long password tokens will remain valid
+	 */
 	public void setPasswordTokenValidFor(Duration validityTime) {
 		this.passwordTokenValidFor = validityTime;
 	}
 
+	/**
+	 * Gets the length of time that password reset tokens will be valid for.
+	 *
+	 * @return how long password reset tokens are valid
+	 */
 	public Duration getPasswordTokenValidFor() {
 		return passwordTokenValidFor;
 	}
 
+	/**
+	 * Gets whether email will be logged to the console or actually delivered.
+	 *
+	 * @return true if email will be logged to the console, false if it will be sent
+	 */
 	public Boolean getEmailDryRun() {
 		return emailDryRun;
 	}
 
+	/**
+	 * Sets whether email should be logged to the console.
+	 *
+	 * @param emailDryRun
+	 *            true if email should be logged to the console instead of sending, false to deliver email
+	 */
 	public void setEmailDryRun(Boolean emailDryRun) {
 		this.emailDryRun = emailDryRun;
 	}
 
+	/**
+	 * Gets whether user accounts are required to have an email address.
+	 *
+	 * @return true if users are required to have an email address
+	 */
 	public Boolean getEmailRequired() {
 		return emailRequired;
 	}
 
+	/**
+	 * Sets whether user accounts are required to have an email address.
+	 *
+	 * @param emailRequired
+	 *            true to require an email address, false if not
+	 */
 	public void setEmailRequired(Boolean emailRequired) {
 		this.emailRequired = emailRequired;
 	}
 
+	/**
+	 * Gets the style of roles allowed.
+	 *
+	 * @see RoleStyle
+	 * @return the style of user roles allowed
+	 */
 	public RoleStyle getRoleStyle() {
 		return roleStyle;
 	}
 
+	/**
+	 * Sets the style of roles allowed.
+	 *
+	 * @see RoleStyle
+	 * @param roleStyle
+	 *            the style of user roles that should be allowed
+	 */
 	public void setRoleStyle(RoleStyle roleStyle) {
 		this.roleStyle = roleStyle;
 	}
 
+	/**
+	 * Gets the path to the JavaScript file used when "octri.authentication.role-style" is "custom".
+	 *
+	 * @return the path to the JavaScript file
+	 */
 	public String getCustomRoleScript() {
 		return customRoleScript;
 	}
 
+	/**
+	 * Sets the path to the JavaScript file used when "octri.authentication.role-style" is "custom". This path should be
+	 * relative to the application's context path.
+	 *
+	 * @param customRoleScript
+	 *            path of the JavaScript file
+	 */
 	public void setCustomRoleScript(String customRoleScript) {
 		this.customRoleScript = customRoleScript;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/SamlAuthenticationConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/SamlAuthenticationConfiguration.java
@@ -49,7 +49,7 @@ public class SamlAuthenticationConfiguration {
 	 *
 	 * TODO: Document the behavior of the default configuration and how to override it here
 	 *
-	 * @return
+	 * @return default SAML 2 authentication provider
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -66,7 +66,7 @@ public class SamlAuthenticationConfiguration {
 	/**
 	 * Creates a default registration repository configured with credentials for the SP and IdP.
 	 *
-	 * @return
+	 * @return default registration repository
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -86,7 +86,8 @@ public class SamlAuthenticationConfiguration {
 	 * Creates a registration resolver from the given registration repository.
 	 *
 	 * @param repository
-	 * @return
+	 *            relying party registration repository
+	 * @return default registration resolver for the repository
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -100,7 +101,8 @@ public class SamlAuthenticationConfiguration {
 	 * Creates a custom logout request resolver that populates the logout request's required NameID format.
 	 *
 	 * @param resolver
-	 * @return
+	 *            relying party registration resolver
+	 * @return default logout request resolver
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -128,7 +130,9 @@ public class SamlAuthenticationConfiguration {
 	/**
 	 * Creates a request filter that generates SAML Service Provider (SP) metadata XML.
 	 *
-	 * @return
+	 * @param resolver
+	 *            relying party registration resolver
+	 * @return default SAML metadata filter
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -139,7 +143,7 @@ public class SamlAuthenticationConfiguration {
 	/**
 	 * Loads the application's SAML decryption credential from the configured private key and certificate locations.
 	 *
-	 * @return
+	 * @return credentials used to decrypt SAML requests
 	 */
 	private Saml2X509Credential loadDecryptionCredential() {
 		var key = readPrivateKey(samlProperties.getDecryptionKeyLocation());
@@ -150,7 +154,7 @@ public class SamlAuthenticationConfiguration {
 	/**
 	 * Loads the application's SAML signing credential from the configured private key and certificate locations.
 	 *
-	 * @return
+	 * @return credentials used to sign SAML requests
 	 */
 	private Saml2X509Credential loadSigningCredential() {
 		var key = readPrivateKey(samlProperties.getSigningKeyLocation());
@@ -163,7 +167,8 @@ public class SamlAuthenticationConfiguration {
 	 * private key data in PKCS #8 format.
 	 *
 	 * @param location
-	 * @return
+	 *            location of the RSA private key file
+	 * @return private key data
 	 */
 	private RSAPrivateKey readPrivateKey(Resource location) {
 		Assert.notNull(location, "Key location cannot be null");
@@ -180,7 +185,8 @@ public class SamlAuthenticationConfiguration {
 	 * X509 certificate data.
 	 *
 	 * @param location
-	 * @return
+	 *            location of the X509 certificate
+	 * @return X509 certificate data
 	 */
 	private X509Certificate readCertificate(Resource location) {
 		Assert.notNull(location, "Certificate location cannot be null");

--- a/authentication_lib/src/main/java/org/octri/authentication/config/SamlProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/SamlProperties.java
@@ -20,9 +20,9 @@ public class SamlProperties {
 	 * The relying party ID is included in the login and metadata URLs and cannot be changed once registered with the
 	 * IdP. Example URLs:
 	 * <br>
-	 * - Metadata: `{{contextPath}}/saml2/service-provider-metadata/{{registrationId}}`<br>
-	 * - Login initiation: `{{contextPath}}/saml2/authenticate/{{registrationId}}`<br>
-	 * - Login completion: `{{contextPath}}/login/saml2/sso/{{registrationId}}`
+	 * - Metadata: <code>{{contextPath}}/saml2/service-provider-metadata/{{registrationId}}</code><br>
+	 * - Login initiation: <code>{{contextPath}}/saml2/authenticate/{{registrationId}}</code><br>
+	 * - Login completion: <code>{{contextPath}}/login/saml2/sso/{{registrationId}}</code>
 	 */
 	private String registrationId = "default";
 
@@ -93,114 +93,268 @@ public class SamlProperties {
 	 */
 	private String logoutPath = "{baseUrl}/logout/saml2/slo";
 
+	/**
+	 * Gets whether SAML authentication is enabled.
+	 * 
+	 * @return true if SAML auth is enabled
+	 */
 	public Boolean getEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Sets whether SAML authentication is enabled.
+	 * 
+	 * @param enabled
+	 *            true if enabled, else false
+	 */
 	public void setEnabled(Boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets the ID of the relying party registration.
+	 * 
+	 * @return ID of the relying party registration
+	 */
 	public String getRegistrationId() {
 		return registrationId;
 	}
 
+	/**
+	 * Sets the ID of the relying party registration.
+	 * 
+	 * @param registrationId
+	 *            the ID of the relying party registration
+	 */
 	public void setRegistrationId(String registrationId) {
 		this.registrationId = registrationId;
 	}
 
+	/**
+	 * Gets the location of the RSA signing key file.
+	 *
+	 * @return the location of the RSA signing key file
+	 */
 	public Resource getSigningKeyLocation() {
 		return signingKeyLocation;
 	}
 
+	/**
+	 * Sets the location of the RSA signing key file.
+	 * 
+	 * @param signingKeyLocation
+	 *            the location of the RSA signing key file
+	 */
 	public void setSigningKeyLocation(Resource signingKeyLocation) {
 		this.signingKeyLocation = signingKeyLocation;
 	}
 
+	/**
+	 * Gets the location of the signing X509 certificate file.
+	 *
+	 * @return the location of the signing X509 certificate file
+	 */
 	public Resource getSigningCertLocation() {
 		return signingCertLocation;
 	}
 
+	/**
+	 * Sets the location of the signing X509 certificate file.
+	 * 
+	 * @param signingCertLocation
+	 *            the location of the signing X509 certificate file
+	 */
 	public void setSigningCertLocation(Resource signingCertLocation) {
 		this.signingCertLocation = signingCertLocation;
 	}
 
+	/**
+	 * Gets the location of the RSA decryption key file.
+	 * 
+	 * @return the location of the RSA decryption key file
+	 */
 	public Resource getDecryptionKeyLocation() {
 		return decryptionKeyLocation;
 	}
 
+	/**
+	 * Sets the location of the RSA decryption key file.
+	 * 
+	 * @param decryptionKeyLocation
+	 *            the location of the RSA decryption key file
+	 */
 	public void setDecryptionKeyLocation(Resource decryptionKeyLocation) {
 		this.decryptionKeyLocation = decryptionKeyLocation;
 	}
 
+	/**
+	 * Gets the location of the decryption X509 certificate file.
+	 * 
+	 * @return the location of the decryption X509 certificate file
+	 */
 	public Resource getDecryptionCertLocation() {
 		return decryptionCertLocation;
 	}
 
+	/**
+	 * Sets the location of the decryption X509 certificate file.
+	 * 
+	 * @param decryptionCertLocation
+	 *            the location of the decryption X509 certificate file
+	 */
 	public void setDecryptionCertLocation(Resource decryptionCertLocation) {
 		this.decryptionCertLocation = decryptionCertLocation;
 	}
 
+	/**
+	 * Gets the IdP metadata URI.
+	 * 
+	 * @return the IdP metadata URI
+	 */
 	public String getIdpMetadataUri() {
 		return idpMetadataUri;
 	}
 
+	/**
+	 * Sets the URI of the IdP metadata.
+	 * 
+	 * @param idpMetadataUri
+	 *            the URI of the IdP metadata
+	 */
 	public void setIdpMetadataUri(String idpMetadataUri) {
 		this.idpMetadataUri = idpMetadataUri;
 	}
 
+	/**
+	 * Gets the name of the group required for login.
+	 * 
+	 * @return the name of the group required for login
+	 */
 	public String getRequiredGroup() {
 		return requiredGroup;
 	}
 
+	/**
+	 * Sets the name of the group required for login.
+	 * 
+	 * @param requiredGroup
+	 *            the name of the group required for login
+	 */
 	public void setRequiredGroup(String requiredGroup) {
 		this.requiredGroup = requiredGroup;
 	}
 
+	/**
+	 * Gets the ID of the SAML attribute used to provide the user ID.
+	 * 
+	 * @return the ID of the SAML attribute used to provide the user ID
+	 */
 	public String getUseridAttribute() {
 		return useridAttribute;
 	}
 
+	/**
+	 * Sets the ID of the SAML attribute used to provide the user ID.
+	 * 
+	 * @param useridAttribute
+	 *            the ID of the SAML attribute used to provide the user ID
+	 */
 	public void setUseridAttribute(String useridAttribute) {
 		this.useridAttribute = useridAttribute;
 	}
 
+	/**
+	 * Gets the ID of the SAML attribute used to provide the user's email.
+	 * 
+	 * @return the ID of the SAML attribute used to provide the user's email
+	 */
 	public String getEmailAttribute() {
 		return emailAttribute;
 	}
 
+	/**
+	 * Sets the ID of the SAML attribute used to provide the user's email.
+	 * 
+	 * @param emailAttribute
+	 *            the ID of the SAML attribute used to provide the user's email
+	 */
 	public void setEmailAttribute(String emailAttribute) {
 		this.emailAttribute = emailAttribute;
 	}
 
+	/**
+	 * Gets the ID of the SAML attribute used to provide the user's first name.
+	 * 
+	 * @return the ID of the SAML attribute used to provide the user's first name
+	 */
 	public String getFirstNameAttribute() {
 		return firstNameAttribute;
 	}
 
+	/**
+	 * Sets the ID of the SAML attribute used to provide the user's first name.
+	 * 
+	 * @param firstNameAttribute
+	 *            the ID of the SAML attribute used to provide the user's first name
+	 */
 	public void setFirstNameAttribute(String firstNameAttribute) {
 		this.firstNameAttribute = firstNameAttribute;
 	}
 
+	/**
+	 * Gets the ID of the SAML attribute used to provide the user's last name.
+	 * 
+	 * @return the ID of the SAML attribute used to provide the user's last name
+	 */
 	public String getLastNameAttribute() {
 		return lastNameAttribute;
 	}
 
+	/**
+	 * Sets the ID of the SAML attribute used to provide the user's last name.
+	 * 
+	 * @param lastNameAttribute
+	 *            the ID of the SAML attribute used to provide the user's last name
+	 */
 	public void setLastNameAttribute(String lastNameAttribute) {
 		this.lastNameAttribute = lastNameAttribute;
 	}
 
+	/**
+	 * Gets the ID of the SAML attribute used to provide the user's group assignments.
+	 * 
+	 * @return the ID of the SAML attribute used to provide the user's group assignments
+	 */
 	public String getGroupAttribute() {
 		return groupAttribute;
 	}
 
+	/**
+	 * Sets the ID of the SAML attribute used to provide the user's group assignments.
+	 * 
+	 * @param groupAttribute
+	 *            the ID of the SAML attribute used to provide the user's group assignments
+	 */
 	public void setGroupAttribute(String groupAttribute) {
 		this.groupAttribute = groupAttribute;
 	}
 
+	/**
+	 * Gets the configured SAML logout path.
+	 * 
+	 * @return the configured SAML logout path
+	 */
 	public String getLogoutPath() {
 		return logoutPath;
 	}
 
+	/**
+	 * Sets the SAML logout path.
+	 * 
+	 * @param logoutPath
+	 *            the SAML logout path
+	 */
 	public void setLogoutPath(String logoutPath) {
 		this.logoutPath = logoutPath;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/TableBasedAuthenticationConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/TableBasedAuthenticationConfiguration.java
@@ -23,8 +23,10 @@ public class TableBasedAuthenticationConfiguration {
 	 * Provides a default authentication provider for table-based accounts.
 	 *
 	 * @param userDetailsService
+	 *            service used to look up user details
 	 * @param passwordEncoder
-	 * @return
+	 *            encodes passwords for storage in the database
+	 * @return default authentication provider for table-based authentication
 	 */
 	@Bean
 	@ConditionalOnMissingBean

--- a/authentication_lib/src/main/java/org/octri/authentication/config/TemplateConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/TemplateConfiguration.java
@@ -50,6 +50,14 @@ public class TemplateConfiguration {
 	private MustacheProperties mustacheProperties;
 	private ApplicationContext applicationContext;
 
+	/**
+	 * Constructor.
+	 * 
+	 * @param mustacheProperties
+	 *            Mustache template configuration
+	 * @param applicationContext
+	 *            Spring application context
+	 */
 	public TemplateConfiguration(MustacheProperties mustacheProperties, ApplicationContext applicationContext) {
 		this.mustacheProperties = mustacheProperties;
 		this.applicationContext = applicationContext;

--- a/authentication_lib/src/main/java/org/octri/authentication/config/UserManagementCustomizerConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/UserManagementCustomizerConfiguration.java
@@ -33,6 +33,11 @@ public class UserManagementCustomizerConfiguration {
     @Autowired
     private EmailNotificationService emailNotificationService;
 
+    /**
+     * Creates the default user management workflow, if not overridden by the application.
+     * 
+     * @return the default user management workflow
+     */
     @Bean
     @ConditionalOnMissingBean(UserManagementCustomizer.class)
     public UserManagementCustomizer defaultUserManagementCustomizer() {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/controller/ErrorController.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/controller/ErrorController.java
@@ -8,22 +8,36 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- * "Used to suppress default (BasicErrorController) functionality: By default
- * Spring Boot adds the error path to the list of paths, ignored by Spring
- * Security."
+ * Used to suppress default (BasicErrorController) functionality: By default Spring Boot adds the error path to the list
+ * of paths, ignored by Spring Security.
  *
  * TODO: Determine whether this is still needed.
  *
- * @see https://github.com/olle/no-auth-for-you/blob/master/spring-boot-1.5.0/src/main/java/com/studiomediatech/bugs/web/ErrorController.java
- * @see https://github.com/spring-projects/spring-boot/issues/1048
+ * @see <a href=
+ *      "https://github.com/olle/no-auth-for-you/blob/master/spring-boot-1.5.0/src/main/java/com/studiomediatech/bugs/web/ErrorController.java">https://github.com/olle/no-auth-for-you/blob/master/spring-boot-1.5.0/src/main/java/com/studiomediatech/bugs/web/ErrorController.java</a>
+ * @see <a href=
+ *      "https://github.com/spring-projects/spring-boot/issues/1048">https://github.com/spring-projects/spring-boot/issues/1048</a>
  */
 @Controller
 public class ErrorController extends BasicErrorController {
 
+	/**
+	 * Constructor
+	 * 
+	 * @param errorAttributes
+	 *            base error attributes
+	 */
 	public ErrorController(ErrorAttributes errorAttributes) {
 		super(errorAttributes, new ErrorProperties());
 	}
 
+	/**
+	 * Renders the error page.
+	 * 
+	 * @param model
+	 *            template model attributes
+	 * @return the error template
+	 */
 	@RequestMapping(value = "/error")
 	public String error(Model model) {
 		return "/error";

--- a/authentication_lib/src/main/java/org/octri/authentication/server/controller/FormAuthenticationController.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/controller/FormAuthenticationController.java
@@ -20,6 +20,21 @@ public class FormAuthenticationController {
 	@Autowired
 	Boolean tableBasedEnabled;
 
+	/**
+	 * Renders the login form.
+	 * 
+	 * @param model
+	 *            template model
+	 * @param passwordChanged
+	 *            present if the form is being rendered after a password change
+	 * @param passwordReset
+	 *            present if the form is being rendered after a password reset
+	 * @param error
+	 *            present if the form is being rendered after an unsuccessful login
+	 * @param request
+	 *            servlet request
+	 * @return the login form
+	 */
 	@GetMapping("login")
 	public String login(Model model, @ModelAttribute("passwordChanged") String passwordChanged,
 			@ModelAttribute("passwordReset") String passwordReset,

--- a/authentication_lib/src/main/java/org/octri/authentication/server/controller/TemplateAdvice.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/controller/TemplateAdvice.java
@@ -39,6 +39,14 @@ public class TemplateAdvice {
 	@Autowired(required = false)
 	private SamlProperties samlProperties;
 
+	/**
+	 * Adds attributes used to render authentication templates to the model used to render the template.
+	 * 
+	 * @param request
+	 *            the current servlet request
+	 * @param model
+	 *            model used to render the template
+	 */
 	@ModelAttribute
 	public void addDefaultAttributes(HttpServletRequest request, Model model) {
 		this.securityHelper = new SecurityHelper(SecurityContextHolder.getContext());

--- a/authentication_lib/src/main/java/org/octri/authentication/server/controller/UserController.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/controller/UserController.java
@@ -185,6 +185,8 @@ public class UserController {
 	 *            The {@link HttpServletRequest}
 	 * @param model
 	 *            Object holding view data
+	 * @param id
+	 *            ID of the user to update
 	 * @return User form template
 	 */
 	@PreAuthorize(MethodSecurityExpressions.ADMIN_OR_SUPER)
@@ -374,6 +376,9 @@ public class UserController {
 		return usernameStyle != null ? usernameStyle.toString() : null;
 	}
 
+	/**
+	 * @return path of JavaScript used for custom role handling
+	 */
 	@ModelAttribute("customRoleScript")
 	public String getCustomRoleScript() {
 		return authenticationProperties.getCustomRoleScript();
@@ -383,6 +388,7 @@ public class UserController {
 	 * Ensure that empty strings are saved as NULL values.
 	 *
 	 * @param binder
+	 *            the data binder to customize
 	 */
 	@InitBinder
 	public void initBinder(WebDataBinder binder) {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/customizer/DefaultUserManagementCustomizer.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/customizer/DefaultUserManagementCustomizer.java
@@ -24,6 +24,18 @@ public class DefaultUserManagementCustomizer implements UserManagementCustomizer
 
     private EmailNotificationService emailNotificationService;
 
+    /**
+     * Constructor
+     * 
+     * @param authenticationProperties
+     *            configuration properties
+     * @param userService
+     *            service used to manipulate user records
+     * @param passwordResetTokenService
+     *            service used to manage password reset token strings
+     * @param emailNotificationService
+     *            service used to send email notifications
+     */
     public DefaultUserManagementCustomizer(OctriAuthenticationProperties authenticationProperties,
             UserService userService, PasswordResetTokenService passwordResetTokenService,
             EmailNotificationService emailNotificationService) {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/customizer/UserManagementCustomizer.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/customizer/UserManagementCustomizer.java
@@ -13,6 +13,9 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 public interface UserManagementCustomizer {
 
+        /**
+         * Default redirect after user creating or updating users.
+         */
         public static final String DEFAULT_REDIRECT = "redirect:/admin/user/list";
 
         /**

--- a/authentication_lib/src/main/java/org/octri/authentication/server/rest/AuthenticationController.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/rest/AuthenticationController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This {@link RestController} handles authentication related requests.
- * 
+ *
  * @author yateam
  */
 @RestController
@@ -15,6 +15,7 @@ public class AuthenticationController {
 
 	/**
 	 * @param user
+	 *            the current principal
 	 * @return Return the authenticated {@link Principal}.
 	 */
 	@RequestMapping("/user")

--- a/authentication_lib/src/main/java/org/octri/authentication/server/rest/UserApiController.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/rest/UserApiController.java
@@ -46,8 +46,10 @@ public class UserApiController {
 	 * Searches the database for the username to determine whether it is taken
 	 *
 	 * @param username
+	 *            username to test
 	 * @param model
-	 * @return
+	 *            template model
+	 * @return a JSON response indicating whether the username is already in use
 	 */
 	@RequestMapping(path = "admin/user/taken/{username}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> taken(@PathVariable("username") String username, Model model) {
@@ -61,7 +63,8 @@ public class UserApiController {
 	 * Searches LDAP for the username and provides user information.
 	 *
 	 * @param username
-	 * @return
+	 *            username to search by
+	 * @return user details if a user with the given username is present in LDAP, or an error message
 	 */
 	@PreAuthorize(MethodSecurityExpressions.ADMIN_OR_SUPER)
 	@PostMapping("admin/user/ldapLookup")

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/AuditLoginAuthenticationFailureHandler.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/AuditLoginAuthenticationFailureHandler.java
@@ -25,7 +25,7 @@ import jakarta.servlet.http.HttpServletRequest;
  * See {@link UserService}
  *
  * Adapted from ChimeraAuthenticationFailureHandler.
- * 
+ *
  * @author yateam
  */
 @Component
@@ -41,8 +41,11 @@ public class AuditLoginAuthenticationFailureHandler extends SimpleUrlAuthenticat
 	 * Creates a new {@link LoginAttempt} record for an unsuccessful login
 	 *
 	 * @param username
+	 *            the username provided
 	 * @param error
+	 *            message describing why the login failed
 	 * @param request
+	 *            the login request
 	 */
 	protected void recordLoginFailure(String username, String error, HttpServletRequest request) {
 		LoginAttempt attempt = new LoginAttempt();
@@ -56,9 +59,11 @@ public class AuditLoginAuthenticationFailureHandler extends SimpleUrlAuthenticat
 
 	/**
 	 * Increments the failed attempts counter
-	 * 
+	 *
 	 * @param username
+	 *            username provided on login
 	 * @param exception
+	 *            exception describing why authentication failed
 	 */
 	protected void recordUserFailedAttempts(String username, AuthenticationException exception) {
 		if (exception.getClass() == BadCredentialsException.class && userService.findByUsername(username) != null) {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/AuditLoginAuthenticationSuccessHandler.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/AuditLoginAuthenticationSuccessHandler.java
@@ -29,6 +29,14 @@ public abstract class AuditLoginAuthenticationSuccessHandler extends SavedReques
 	@Autowired
 	private UserService userService;
 
+	/**
+	 * Records a successful login attempt.
+	 *
+	 * @param auth
+	 *            authenticated principal
+	 * @param request
+	 *            the successful login request
+	 */
 	protected void recordLoginSuccess(Authentication auth, HttpServletRequest request) {
 		LoginAttempt attempt = new LoginAttempt();
 		attempt.setUsername(auth.getName());
@@ -38,6 +46,14 @@ public abstract class AuditLoginAuthenticationSuccessHandler extends SavedReques
 		loginAttemptService.save(attempt);
 	}
 
+	/**
+	 * Resets the failed login attempts for the given authenticated principal back to zero.
+	 *
+	 * @param auth
+	 *            authenticated principal
+	 * @throws UserManagementException
+	 *             if the user cannot be saved
+	 */
 	protected void resetUserFailedAttempts(Authentication auth)
 			throws UserManagementException {
 		User user = userService.findByUsername(auth.getName());

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/AuthenticationUrlHelper.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/AuthenticationUrlHelper.java
@@ -8,42 +8,52 @@ public class AuthenticationUrlHelper {
 	private String baseUrl;
 	private String contextPath;
 
+	/**
+	 * Constructor
+	 * 
+	 * @param baseUrl
+	 *            the application's base URL, including the hostname, port, and scheme.
+	 * @param contextPath
+	 *            the application context path (initial path segment after the base URL)
+	 */
 	public AuthenticationUrlHelper(String baseUrl, String contextPath) {
 		this.baseUrl = baseUrl;
 		this.contextPath = contextPath;
 	}
 
 	/**
-	 * Get the application's base URL prefix, including the hostname, port, and scheme.
+	 * Gets the application's base URL, including the hostname, port, and scheme.
 	 *
-	 * @return
+	 * @return the configured base URL
 	 */
 	public String getBaseUrl() {
 		return baseUrl;
 	}
 
 	/**
-	 * Set the application's base URL prefix, including the hostname, port, and scheme.
+	 * Sets the application's base URL, including the hostname, port, and scheme.
 	 *
 	 * @param baseUrl
+	 *            the base URL to set
 	 */
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
 	}
 
 	/**
-	 * Get the application's context path.
+	 * Gets the application's context path (initial path segment after the base URL).
 	 *
-	 * @return
+	 * @return the configured context path
 	 */
 	public String getContextPath() {
 		return contextPath;
 	}
 
 	/**
-	 * Set the application's context path.
+	 * Sets the application's context path.
 	 *
 	 * @param contextPath
+	 *            the context path to set
 	 */
 	public void setContextPath(String contextPath) {
 		this.contextPath = contextPath;
@@ -71,6 +81,7 @@ public class AuthenticationUrlHelper {
 	 * The full URL for resetting a password.
 	 *
 	 * @param resetToken
+	 *            a single-use password reset token string
 	 * @return The URL for resetting user's password, including token.
 	 */
 	public String getPasswordResetUrl(final String resetToken) {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/AuthenticationUserDetails.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/AuthenticationUserDetails.java
@@ -16,8 +16,19 @@ public class AuthenticationUserDetails extends User {
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * The user's unique ID
+	 */
 	private long userId;
 
+	/**
+	 * Constructor
+	 * 
+	 * @param user
+	 *            a user entity
+	 * @param authorities
+	 *            user authorities (e.g. roles)
+	 */
 	public AuthenticationUserDetails(org.octri.authentication.server.security.entity.User user,
 			Collection<? extends GrantedAuthority> authorities) {
 		super(user.getUsername(), (user.getPassword() == null ? "Invalid password" : user.getPassword()),
@@ -26,10 +37,21 @@ public class AuthenticationUserDetails extends User {
 		this.userId = user.getId();
 	}
 
+	/**
+	 * Gets the user's unique ID
+	 * 
+	 * @return the user's ID value
+	 */
 	public long getUserId() {
 		return userId;
 	}
 
+	/**
+	 * Sets the user's unique ID
+	 * 
+	 * @param userId
+	 *            the user's ID value
+	 */
 	public void setUserId(long userId) {
 		this.userId = userId;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/JsonResponseAuthenticationSuccessHandler.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/JsonResponseAuthenticationSuccessHandler.java
@@ -29,6 +29,12 @@ public class JsonResponseAuthenticationSuccessHandler extends AuditLoginAuthenti
 
 	private final ObjectMapper mapper;
 
+	/**
+	 * Constructor.
+	 * 
+	 * @param mappingJackson2HttpMessageConverter
+	 *            JSON message converter
+	 */
 	public JsonResponseAuthenticationSuccessHandler(
 			MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter) {
 		this.mapper = mappingJackson2HttpMessageConverter.getObjectMapper();

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/LdapUserDetailsContextMapper.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/LdapUserDetailsContextMapper.java
@@ -18,10 +18,10 @@ import org.springframework.util.Assert;
 /**
  * An implementation of Spring Security's {@link UserDetailsContextMapper}, to generate {@link UserDetails} from an LDAP
  * context.
- * 
+ *
  * We basically just use this to ensure that a valid user and password were in LDAP then create a
  * {@link UserDetails} using information from the database
- * 
+ *
  * Implementation essentially lifted from Chimera.
  *
  * @author harrelst
@@ -33,13 +33,19 @@ public class LdapUserDetailsContextMapper implements UserDetailsContextMapper {
 
 	private UserDetailsService userDetailsService;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param userDetailsService
+	 *            service used to get database user details
+	 */
 	public LdapUserDetailsContextMapper(UserDetailsService userDetailsService) {
 		this.userDetailsService = userDetailsService;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.springframework.security.ldap.userdetails.UserDetailsContextMapper#mapUserFromContext(org.springframework.
 	 * ldap.core.DirContextOperations, java.lang.String, java.util.Collection)
@@ -54,7 +60,7 @@ public class LdapUserDetailsContextMapper implements UserDetailsContextMapper {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.springframework.security.ldap.userdetails.UserDetailsContextMapper#mapUserToContext(org.springframework.
 	 * security.core.userdetails.UserDetails, org.springframework.ldap.core.DirContextAdapter)
 	 */
@@ -67,6 +73,9 @@ public class LdapUserDetailsContextMapper implements UserDetailsContextMapper {
 	 * Check to determine if user's account has been suspended locally. Conceptually this doesn't seem like the best
 	 * place for these checks, but the LdapAuthenticationProvider never does them and waiting until after we have the
 	 * UserDetails object is consistent with how the DaoAuthenticationProvider works.
+	 *
+	 * @param user
+	 *            the user account to check
 	 */
 	protected void doPreAuthenticationChecks(UserDetails user) {
 		Assert.notNull(user, "user may not be null");

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/SecurityHelper.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/SecurityHelper.java
@@ -26,14 +26,34 @@ import org.springframework.util.Assert;
  */
 public class SecurityHelper {
 
+	/**
+	 * Base user roles
+	 */
 	public static enum Role {
-		ROLE_USER, ROLE_ADMIN, ROLE_SUPER;
+		/**
+		 * Regular user account
+		 */
+		ROLE_USER,
+		/**
+		 * Admin user account
+		 */
+		ROLE_ADMIN,
+		/**
+		 * Superuser account
+		 */
+		ROLE_SUPER;
 	}
 
 	private Collection<? extends GrantedAuthority> authorities = Collections.emptyList();
 
 	private Authentication authentication;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param context
+	 *            Spring Security {@link SecurityContext}
+	 */
 	public SecurityHelper(SecurityContext context) {
 		authentication = context.getAuthentication();
 		if (authentication != null) {
@@ -44,7 +64,7 @@ public class SecurityHelper {
 	/**
 	 * Checks if the user is authenticated and not anonymous.
 	 *
-	 * @return
+	 * @return true if the user is a non-anonymous, authenticated user
 	 */
 	public boolean isLoggedIn() {
 		return isAuthenticated() && !isAnonymous();
@@ -54,7 +74,7 @@ public class SecurityHelper {
 	 * Checks if the user is authenticated. The anonymous user is authenticated by default. Use {@link #isLoggedIn()} if
 	 * you want to ensure the user is authenticated but not anonymous.
 	 *
-	 * @return
+	 * @return true if the user is authenticated
 	 */
 	public boolean isAuthenticated() {
 		return authentication == null ? false : authentication.isAuthenticated();
@@ -63,7 +83,7 @@ public class SecurityHelper {
 	/**
 	 * Checks if the user is an anonymously authenticated user.
 	 *
-	 * @return
+	 * @return true if the user is not authenticated or represented by an {@link AnonymousAuthenticationToken}
 	 */
 	public boolean isAnonymous() {
 		return authentication == null ? true : authentication instanceof AnonymousAuthenticationToken;
@@ -75,7 +95,7 @@ public class SecurityHelper {
 	 *
 	 * @param testUserId
 	 *            The id of the user being edited.
-	 * @return True if the currently authenticated user can edit a user.
+	 * @return True if the currently authenticated user can edit the user.
 	 */
 	public boolean canEditUser(Long testUserId) {
 		return isAdminOrSuper() && authenticationUserDetails().getUserId() != testUserId;
@@ -84,7 +104,7 @@ public class SecurityHelper {
 	/**
 	 * Get the authenticated username.
 	 *
-	 * @return
+	 * @return the username of the currently-authenticated user, or empty string if not authenticated
 	 */
 	public String username() {
 		return authentication == null ? "" : authentication.getName();
@@ -93,7 +113,7 @@ public class SecurityHelper {
 	/**
 	 * Get the current {@link AuthenticationUserDetails}.
 	 *
-	 * @return
+	 * @return user details for the current user, null if not authenticated
 	 */
 	public AuthenticationUserDetails authenticationUserDetails() {
 		return authentication == null ? null : (AuthenticationUserDetails) authentication.getPrincipal();
@@ -102,18 +122,18 @@ public class SecurityHelper {
 	/**
 	 * Check if the user has at least one of the roles: ADMIN or SUPER.
 	 *
-	 * @return
+	 * @return true if the user has the ADMIN or SUPER role
 	 */
 	public boolean isAdminOrSuper() {
 		return hasAnyRole(Arrays.asList(Role.ROLE_ADMIN, Role.ROLE_SUPER));
 	}
 
 	/**
-	 * Checks if user contains the given role.
+	 * Checks if user has been granted the given role.
 	 *
 	 * @param role
 	 *            A user role.
-	 * @return True if the user contains the role.
+	 * @return True if the user has been granted the role.
 	 */
 	public boolean hasRole(Role role) {
 		return hasRoleName(role.name());
@@ -124,7 +144,8 @@ public class SecurityHelper {
 	 * just the default roles set up in this library.
 	 *
 	 * @param roleName
-	 * @return True if the user contains the roleName
+	 *            name of the role to check
+	 * @return True if the user has been granted the role matching the given roleName
 	 */
 	public boolean hasRoleName(String roleName) {
 		return authorities == null ? false
@@ -132,31 +153,33 @@ public class SecurityHelper {
 	}
 
 	/**
-	 * Checks if a user contains at least one of the roles.
+	 * Checks if a user has been granted at least one of the roles.
 	 *
 	 * @param roles
 	 *            A list of user roles.
-	 * @return True if the user contains one of the roles.
+	 * @return True if the user has been granted one of the roles.
 	 */
 	public boolean hasAnyRole(List<Role> roles) {
 		return hasAnyRoleName(roles.stream().map(role -> role.name()).collect(Collectors.toList()));
 	}
 
 	/**
-	 * Checks if a user contains at least one of the role names.
+	 * Checks if a user has been granted at least one of the role names.
 	 *
 	 * @param roleNames
-	 * @return True if the user contains at least one of the role names.
+	 *            a list of user role names
+	 * @return True if the user has been granted a role matching at least one of the role names.
 	 */
 	public boolean hasAnyRoleName(List<String> roleNames) {
 		return roleNames.stream().anyMatch(name -> hasRoleName(name));
 	}
 
 	/**
-	 * Whether the given user has an ohsu email account.
+	 * Whether the given user has an OHSU email account.
 	 *
 	 * @param user
-	 * @return
+	 *            user account
+	 * @return true if the user's email matches the ohsu.edu domain
 	 */
 	public static boolean hasOHSUEmail(User user) {
 		return hasEmailDomain(user, "ohsu.edu");
@@ -166,8 +189,10 @@ public class SecurityHelper {
 	 * Whether the user's email matches the given domain.
 	 *
 	 * @param user
+	 *            user account
 	 * @param matchDomain
-	 * @return
+	 *            email domain
+	 * @return true if the user's email matches the given domain
 	 */
 	public static boolean hasEmailDomain(User user, String matchDomain) {
 		Assert.notNull(user, "User cannot be null");

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/TableBasedAuthenticationProvider.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/TableBasedAuthenticationProvider.java
@@ -7,7 +7,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-
 /**
  * @author harrelst
  */
@@ -16,8 +15,12 @@ public class TableBasedAuthenticationProvider extends DaoAuthenticationProvider 
 	Log log = LogFactory.getLog(TableBasedAuthenticationProvider.class);
 
 	/**
+	 * Constructor.
+	 *
 	 * @param userDetailsService
+	 *            service used to look up user details
 	 * @param passwordEncoder
+	 *            encodes passwords for storage in the database
 	 */
 	public TableBasedAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
 		this.setUserDetailsService(userDetailsService);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AbstractEntity.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AbstractEntity.java
@@ -23,25 +23,46 @@ public abstract class AbstractEntity implements Serializable, Identified {
 
 	private static final long serialVersionUID = 3042616837618435959L;
 
+	/**
+	 * Unique identifier for the entity.
+	 */
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column
 	protected Long id;
 
+	/**
+	 * Default constructor.
+	 */
 	public AbstractEntity() {
 		super();
 	}
 
+	/**
+	 * Convenience constructor that sets the {@link #id} property.
+	 *
+	 * @param id
+	 *            unique identifier value
+	 */
 	public AbstractEntity(Long id) {
 		super();
 		this.id = id;
 	}
 
+	/**
+	 * Gets the entity's ID.
+	 */
 	@Override
 	public Long getId() {
 		return this.id;
 	}
 
+	/**
+	 * Sets the entity's ID.
+	 * 
+	 * @param id
+	 *            unique identifier value
+	 */
 	public void setId(Long id) {
 		this.id = id;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AuthenticationMethod.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AuthenticationMethod.java
@@ -7,7 +7,20 @@ import org.octri.authentication.server.view.Labelled;
  */
 public enum AuthenticationMethod implements Labelled {
 
-	LDAP("LDAP"), SAML("SAML"), TABLE_BASED("Table Based");
+	/**
+	 * Lightweight Directory Access Protocol (LDAP) authentication
+	 */
+	LDAP("LDAP"),
+
+	/**
+	 * Security Assertion Markup Language (SAML) 2.0 authentication
+	 */
+	SAML("SAML"),
+
+	/**
+	 * Table-based authentication - password hash is stored in the database
+	 */
+	TABLE_BASED("Table Based");
 
 	private String label;
 

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/LoginAttempt.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/LoginAttempt.java
@@ -63,67 +63,154 @@ public class LoginAttempt {
 	@Column(columnDefinition = "TEXT")
 	private String errorMessage;
 
-	// ---- Accessors --------
+	/**
+	 * Gets the record's unique ID.
+	 *
+	 * @return the unique ID
+	 */
 	public long getId() {
 		return id;
 	}
 
+	/**
+	 * Sets the record's unique ID.
+	 *
+	 * @param id
+	 *            the unique ID
+	 */
 	public void setId(long id) {
 		this.id = id;
 	}
 
+	/**
+	 * Gets the record's optimistic locking version.
+	 *
+	 * @return the version
+	 */
 	public Integer getVersion() {
 		return version;
 	}
 
+	/**
+	 * Sets the record's optimistic locking version.
+	 *
+	 * @param version
+	 *            the version
+	 */
 	public void setVersion(Integer version) {
 		this.version = version;
 	}
 
+	/**
+	 * Gets the username provided in the login request.
+	 *
+	 * @return the username provided
+	 */
 	public String getUsername() {
 		return username;
 	}
 
+	/**
+	 * Sets the username provided in the login request.
+	 *
+	 * @param username
+	 *            the username provided
+	 */
 	public void setUsername(String username) {
 		this.username = username;
 	}
 
+	/**
+	 * Gets the client IP address provided in the login request.
+	 *
+	 * @return the client IP address
+	 */
 	public String getIpAddress() {
 		return ipAddress;
 	}
 
+	/**
+	 * Sets the client IP address provided in the login request.
+	 *
+	 * @param ipAddress
+	 *            the client IP address
+	 */
 	public void setIpAddress(String ipAddress) {
 		this.ipAddress = ipAddress;
 	}
 
+	/**
+	 * Gets the timestamp of the login request.
+	 *
+	 * @return the request timestamp
+	 */
 	public Date getAttemptedAt() {
 		return attemptedAt;
 	}
 
+	/**
+	 * Sets the timestamp of the login request.
+	 *
+	 * @param attemptedAt
+	 *            the request timestamp
+	 */
 	public void setAttemptedAt(Date attemptedAt) {
 		this.attemptedAt = attemptedAt;
 	}
 
+	/**
+	 * Gets whether the user successfully logged in.
+	 *
+	 * @return true if the attempt was successful, false otherwise
+	 */
 	public Boolean getSuccessful() {
 		return successful;
 	}
 
+	/**
+	 * Sets whether the user successfully logged in.
+	 *
+	 * @param successful
+	 *            true if the attempt was successful, false otherwise
+	 */
 	public void setSuccessful(Boolean successful) {
 		this.successful = successful;
 	}
 
+	/**
+	 * Gets the reason that the login attempt failed.
+	 *
+	 * @return the reason that the login attempt failed
+	 */
 	public String getErrorType() {
 		return errorType;
 	}
 
+	/**
+	 * Sets the reason that the login attempt failed.
+	 *
+	 * @param errorType
+	 *            the reason that the login attempt failed
+	 */
 	public void setErrorType(String errorType) {
 		this.errorType = errorType;
 	}
 
+	/**
+	 * Gets the optional detailed error message describing why the login attempt failed.
+	 *
+	 * @return the detailed error message
+	 */
 	public String getErrorMessage() {
 		return errorMessage;
 	}
 
+	/**
+	 * Sets the optional detailed error message describing why the login attempt failed.
+	 *
+	 * @param errorMessage
+	 *            the detailed error message
+	 */
 	public void setErrorMessage(String errorMessage) {
 		this.errorMessage = errorMessage;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/PasswordResetToken.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/PasswordResetToken.java
@@ -16,8 +16,7 @@ import jakarta.validation.constraints.NotNull;
 
 /**
  * Holds a random token (UUID) generated at the time of the request, the {@link User} that requested the password reset,
- * and an expiration date for the request. A token is generated automatically when constructing a new
- * {@link PasswordResetToken} using {@link #PasswordResetToken(User)} as well as an expiry date.
+ * and an expiration date for the request.
  *
  * @author sams
  */
@@ -51,42 +50,97 @@ public class PasswordResetToken {
 	public PasswordResetToken() {
 	}
 
+	/**
+	 * Gets the record's unique ID.
+	 * 
+	 * @return the unique ID
+	 */
 	public Long getId() {
 		return id;
 	}
 
+	/**
+	 * Sets the record's unique ID.
+	 * 
+	 * @param id
+	 *            the ID to set
+	 */
 	public void setId(Long id) {
 		this.id = id;
 	}
 
+	/**
+	 * Gets the token string.
+	 * 
+	 * @return the token string
+	 */
 	public String getToken() {
 		return token;
 	}
 
+	/**
+	 * Sets the token string.
+	 * 
+	 * @param token
+	 *            the token string to set
+	 */
 	public void setToken(String token) {
 		this.token = token;
 	}
 
+	/**
+	 * Gets the user account that can be reset using the token.
+	 * 
+	 * @return the associated user account
+	 */
 	public User getUser() {
 		return user;
 	}
 
+	/**
+	 * Sets the user account that can be reset using the token.
+	 * 
+	 * @param user
+	 *            a user account
+	 */
 	public void setUser(User user) {
 		this.user = user;
 	}
 
+	/**
+	 * Gets the timestamp when the token expires and can no longer be used.
+	 * 
+	 * @return when the token expires
+	 */
 	public Date getExpiryDate() {
 		return expiryDate;
 	}
 
+	/**
+	 * Sets the timestamp when the token expires and can no longer be used.
+	 * 
+	 * @param expiryDate
+	 *            when the token should expire
+	 */
 	public void setExpiryDate(Date expiryDate) {
 		this.expiryDate = expiryDate;
 	}
 
+	/**
+	 * Gets the URL that initiates a password reset using the token.
+	 * 
+	 * @return password reset URL
+	 */
 	public String getTokenUrl() {
 		return tokenUrl;
 	}
 
+	/**
+	 * Sets the URL that initiates a password reset using the token.
+	 * 
+	 * @param tokenUrl
+	 *            password reset URL
+	 */
 	public void setTokenUrl(String tokenUrl) {
 		this.tokenUrl = tokenUrl;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/SessionEvent.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/SessionEvent.java
@@ -28,32 +28,66 @@ public class SessionEvent extends AbstractEntity {
 	 * Enumeration of event types such as login and logout.
 	 */
 	public enum EventType {
-		LOGIN, LOGOUT, IMPERSONATION
+		/**
+		 * Successful user login
+		 */
+		LOGIN,
+
+		/**
+		 * Logout due to user action or session timeout
+		 */
+		LOGOUT,
+
+		/**
+		 * Admin account impersonating a regular user
+		 */
+		IMPERSONATION
 	}
 
+	/**
+	 * Optimistic locking version.
+	 */
 	@Version
 	protected Integer version;
 
+	/**
+	 * Timestamp when the record was created.
+	 */
 	@CreatedDate
 	@Temporal(TemporalType.TIMESTAMP)
 	@Column(updatable = false)
 	protected Date createdAt;
 
+	/**
+	 * Timestamp when the record was last updated.
+	 */
 	@LastModifiedDate
 	@Temporal(TemporalType.TIMESTAMP)
 	protected Date updatedAt;
 
+	/**
+	 * ID of the user session that triggered the event.
+	 */
 	@NotNull
 	private String sessionId;
 
+	/**
+	 * The type of event being recorded.
+	 */
 	@NotNull
 	@Enumerated(EnumType.STRING)
 	private EventType event;
 
+	/**
+	 * The user account that triggered the event.
+	 */
 	@NotNull
 	@ManyToOne
 	private User user;
 
+	/**
+	 * The user account being impersonated.
+	 */
 	@ManyToOne
 	private User asUser;
 
@@ -66,8 +100,14 @@ public class SessionEvent extends AbstractEntity {
 	/**
 	 * All fields constructor.
 	 *
+	 * @param sessionId
+	 *            the session ID
 	 * @param eventType
+	 *            the type of event being recorded
 	 * @param user
+	 *            the user account that triggered the event
+	 * @param asUser
+	 *            the user account being impersonated, if event is {@link EventType#IMPERSONATION}
 	 */
 	public SessionEvent(final String sessionId, final EventType eventType, final User user, final User asUser) {
 		this.sessionId = sessionId;
@@ -76,58 +116,137 @@ public class SessionEvent extends AbstractEntity {
 		this.asUser = asUser;
 	}
 
+	/**
+	 * Gets the optimistic locking version.
+	 *
+	 * @return optimistic locking version
+	 */
 	public Integer getVersion() {
 		return version;
 	}
 
+	/**
+	 * Sets the optimistic locking version
+	 *
+	 * @param version
+	 *            optimistic locking version
+	 */
 	public void setVersion(Integer version) {
 		this.version = version;
 	}
 
+	/**
+	 * Gets the timestamp when the event record was created.
+	 *
+	 * @return when the event record was created
+	 */
 	public Date getCreatedAt() {
 		return createdAt;
 	}
 
+	/**
+	 * Sets the timestamp when the event record was created.
+	 *
+	 * @param createdAt
+	 *            when the event record was created
+	 */
 	public void setCreatedAt(Date createdAt) {
 		this.createdAt = createdAt;
 	}
 
+	/**
+	 * Gets the timestamp when the event record was last updated.
+	 *
+	 * @return when the event record was last updated
+	 */
 	public Date getUpdatedAt() {
 		return updatedAt;
 	}
 
+	/**
+	 * Sets the timestamp when the event record was last updated.
+	 *
+	 * @param updatedAt
+	 *            when the event record was last updated
+	 */
 	public void setUpdatedAt(Date updatedAt) {
 		this.updatedAt = updatedAt;
 	}
 
+	/**
+	 * Gets the ID of the user session that triggered the event.
+	 *
+	 * @return the session ID
+	 */
 	public String getSessionId() {
 		return sessionId;
 	}
 
+	/**
+	 * Sets the ID of the user session that triggered the event.
+	 *
+	 * @param sessionId
+	 *            the session ID
+	 */
 	public void setSessionId(String sessionId) {
 		this.sessionId = sessionId;
 	}
 
+	/**
+	 * Gets the type of event being recorded.
+	 *
+	 * @see EventType
+	 * @return the type of event
+	 */
 	public EventType getEvent() {
 		return event;
 	}
 
+	/**
+	 * Sets the type of event being recorded.
+	 *
+	 * @see EventType
+	 * @param event
+	 *            the type of event
+	 */
 	public void setEvent(EventType event) {
 		this.event = event;
 	}
 
+	/**
+	 * Gets the user account that triggered the event.
+	 *
+	 * @return user account that triggered the event
+	 */
 	public User getUser() {
 		return user;
 	}
 
+	/**
+	 * Sets the user account that triggered the event.
+	 *
+	 * @param user
+	 *            user account that triggered the event
+	 */
 	public void setUser(User user) {
 		this.user = user;
 	}
 
+	/**
+	 * Gets the user being impersonated. Only valid if event is {@link EventType#IMPERSONATION}.
+	 *
+	 * @return the user account being impersonated
+	 */
 	public User getAsUser() {
 		return asUser;
 	}
 
+	/**
+	 * Sets the user being impersonated. Only valid if event is {@link EventType#IMPERSONATION}.
+	 *
+	 * @param asUser
+	 *            the user account being impersonated
+	 */
 	public void setAsUser(User asUser) {
 		this.asUser = asUser;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/User.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/User.java
@@ -37,6 +37,9 @@ public class User extends AbstractEntity implements Labelled {
 
 	private static final String INVALID_EMAIL_MESSAGE = "Please provide a valid email address";
 
+	/**
+	 * Default constructor.
+	 */
 	public User() {
 		super();
 		setDefaults();
@@ -52,58 +55,101 @@ public class User extends AbstractEntity implements Labelled {
 		this.consecutiveLoginFailures = 0;
 	}
 
+	/**
+	 * The username used to identify the user.
+	 */
 	@Column(unique = true)
 	@NotNull(message = "Username is required")
 	@Size(max = 320, min = 1, message = "Username must be 1-320 characters")
 	private String username;
 
+	/**
+	 * Password hash.
+	 */
 	private String password;
 
+	/**
+	 * Whether the account is enabled for login.
+	 */
 	@NotNull(message = "Enabled must be Yes or No")
 	private Boolean enabled;
 
+	/**
+	 * Whether the account has been locked by failed login attempts.
+	 */
 	@NotNull(message = "Account locked must be Yes or No")
 	private Boolean accountLocked;
 
+	/**
+	 * The user's first name (given name).
+	 */
 	@NotNull(message = "First name is required")
 	@Size(max = 50, min = 1, message = "First name must be 1-50 characters")
 	protected String firstName;
 
+	/**
+	 * The user's last name (family name, surname).
+	 */
 	@NotNull(message = "Last name is required")
 	@Size(max = 50, min = 1, message = "Last name must be 1-50 characters")
 	protected String lastName;
 
+	/**
+	 * The institution the user is associated with. Optional, primarily for use with LDAP.
+	 */
 	@Size(max = 100, min = 1, message = "Institution must be 1-50 characters")
 	private String institution;
 
 	/**
-	 * We can add additional email constraints if required.
+	 * The user's email address.
 	 *
-	 * @see http://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#section-builtin-constraints
+	 * @see <a href=
+	 *      "http://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#section-builtin-constraints">Built-in
+	 *      constraints</a>
 	 */
 	@Email(message = INVALID_EMAIL_MESSAGE, regexp = VALID_EMAIL_REGEX, groups = Emailable.class)
 	@NotNull(message = "Email is required", groups = Emailable.class)
 	@Size(max = 320, min = 1, message = "Email must be between 1 and 320 characters", groups = Emailable.class)
 	private String email;
 
+	/**
+	 * The number of failed login attempts since the last successful login.
+	 */
 	private Integer consecutiveLoginFailures;
 
+	/**
+	 * Timestamp when the account will expire. After this timestamp, login will not be allowed.
+	 */
 	@Temporal(TemporalType.TIMESTAMP)
 	@DateTimeFormat(style = "S-")
 	private Date accountExpirationDate;
 
+	/**
+	 * Timestamp when the user's credentials will expire. After this timestamp, their password must be changed.
+	 */
 	@Temporal(TemporalType.TIMESTAMP)
 	@DateTimeFormat(style = "S-")
 	private Date credentialsExpirationDate;
 
+	/**
+	 * User roles assigned the user has been assigned.
+	 */
 	@ManyToMany(cascade = CascadeType.ALL)
 	@JoinTable(name = "user_user_role", joinColumns = @JoinColumn(name = "user", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "user_role", referencedColumnName = "id"))
 	private List<UserRole> userRoles;
 
+	/**
+	 * The method used to authenticate the user.
+	 */
 	@Enumerated(EnumType.STRING)
 	@NotNull
 	private AuthenticationMethod authenticationMethod;
 
+	/**
+	 * Gets whether the user account is allowed to log in.
+	 *
+	 * @return true if enabled, false if not
+	 */
 	public boolean isEnabled() {
 		if (this.enabled != null && this.enabled) {
 			return true;
@@ -112,15 +158,21 @@ public class User extends AbstractEntity implements Labelled {
 	}
 
 	/**
-	 * NOTE the type has to match isEnabled which is considered a "getter" by the java bean world
-	 * In other words Springs BeanWrapper will not find this setter if the types don't match
+	 * Sets whether the user account is allowed to log in.
 	 *
+	 * @see #setEnabled(Boolean)
 	 * @param enabled
+	 *            true to enable login, false if not
 	 */
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets whether the account is locked because of failed login attempts.
+	 *
+	 * @return true if locked, false if not
+	 */
 	public Boolean getAccountLocked() {
 		if (accountLocked == null) {
 			return false;
@@ -128,6 +180,11 @@ public class User extends AbstractEntity implements Labelled {
 		return accountLocked;
 	}
 
+	/**
+	 * Gets the number of failed login attempts since the last successful login.
+	 *
+	 * @return the number of login failures
+	 */
 	public Integer getConsecutiveLoginFailures() {
 		if (consecutiveLoginFailures == null) {
 			return 0;
@@ -140,7 +197,8 @@ public class User extends AbstractEntity implements Labelled {
 	 * where you need to display a date in the UI for Hibernate fields of type timestamp.
 	 *
 	 * @param timestamp
-	 * @return Returns a string representation of Date, or empty string if timestamp is null.
+	 *            the date to convert
+	 * @return a string representation of Date, or empty string if timestamp is null.
 	 */
 	private String timestampToDateString(Date timestamp) {
 		if (timestamp == null) {
@@ -150,126 +208,303 @@ public class User extends AbstractEntity implements Labelled {
 				.format(DateTimeFormatter.ofPattern("MM/dd/yyyy"));
 	}
 
+	/**
+	 * Gets the username used to log in.
+	 *
+	 * @return the user's username
+	 */
 	public String getUsername() {
 		return this.username;
 	}
 
+	/**
+	 * Sets the username used to log in.
+	 *
+	 * @param username
+	 *            the user's username
+	 */
 	public void setUsername(String username) {
 		this.username = username;
 	}
 
+	/**
+	 * Gets the password hash for table-based authentication.
+	 *
+	 * @return a hashed password value
+	 */
 	public String getPassword() {
 		return this.password;
 	}
 
+	/**
+	 * Sets the password hash for table-based authentication.
+	 *
+	 * @param password
+	 *            a hashed password value
+	 */
 	public void setPassword(String password) {
 		this.password = password;
 	}
 
+	/**
+	 * Gets whether the account is allowed to log in.
+	 *
+	 * @see #isEnabled()
+	 * @return true if enabled, false if not
+	 */
 	public Boolean getEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Sets whether the account is allowed to log in.
+	 *
+	 * @see #setEnabled(boolean)
+	 * @param enabled
+	 *            true to enable, false if not
+	 */
 	public void setEnabled(Boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets the user's first name (given name).
+	 *
+	 * @return the user's first name
+	 */
 	public String getFirstName() {
 		return this.firstName;
 	}
 
+	/**
+	 * Sets the user's first name (given name).
+	 *
+	 * @param firstName
+	 *            the user's first name
+	 */
 	public void setFirstName(String firstName) {
 		this.firstName = firstName;
 	}
 
+	/**
+	 * Gets the user's last name (family name, surname).
+	 *
+	 * @return the user's last name
+	 */
 	public String getLastName() {
 		return this.lastName;
 	}
 
+	/**
+	 * Sets the user's last name (family name, surname).
+	 *
+	 * @param lastName
+	 *            the user's last name
+	 */
 	public void setLastName(String lastName) {
 		this.lastName = lastName;
 	}
 
+	/**
+	 * Gets the institution the user is associated with (optional, primarily for LDAP accounts).
+	 *
+	 * @return the user's institution
+	 */
 	public String getInstitution() {
 		return this.institution;
 	}
 
+	/**
+	 * Sets the institution the user is associated with (optional, primarily for LDAP accounts).
+	 *
+	 * @param institution
+	 *            the user's institution
+	 */
 	public void setInstitution(String institution) {
 		this.institution = institution;
 	}
 
+	/**
+	 * Gets the user's email address.
+	 *
+	 * @return the user's email address
+	 */
 	public String getEmail() {
 		return this.email;
 	}
 
+	/**
+	 * Sets the user's email address.
+	 *
+	 * @param email
+	 *            the user's email address
+	 */
 	public void setEmail(String email) {
 		this.email = email;
 	}
 
+	/**
+	 * Sets whether the account has been locked because of failed login attempts.
+	 *
+	 * @param accountLocked
+	 *            true if the account is locked, false if not
+	 */
 	public void setAccountLocked(Boolean accountLocked) {
 		this.accountLocked = accountLocked;
 	}
 
+	/**
+	 * Gets whether the user account has expired ({@link #accountExpirationDate} is in the past).
+	 *
+	 * @return true if the account has expired, false if not
+	 */
 	public Boolean getAccountExpired() {
 		return accountExpirationDate != null && accountExpirationDate.before(Date.from(Instant.now()));
 	}
 
+	/**
+	 * Gets whether the user's credentials have expired ({@link #credentialsExpirationDate} is in the past).
+	 *
+	 * @return true if the user's credentials have expired, false if not
+	 */
 	public Boolean getCredentialsExpired() {
 		return credentialsExpirationDate != null && credentialsExpirationDate.before(Date.from(Instant.now()));
 	}
 
+	/**
+	 * Sets the count of failed login attempts since the last successful login.
+	 *
+	 * @param consecutiveLoginFailures
+	 *            the count of failed attempts
+	 */
 	public void setConsecutiveLoginFailures(Integer consecutiveLoginFailures) {
 		this.consecutiveLoginFailures = consecutiveLoginFailures;
 	}
 
+	/**
+	 * Gets the timestamp when the user account expires. Login will not be allowed afterward.
+	 *
+	 * @return the timestamp when the user account expires
+	 */
 	public Date getAccountExpirationDate() {
 		return accountExpirationDate;
 	}
 
+	/**
+	 * Gets a string representation of the day when the user account expires.
+	 *
+	 * @return stringified account expiration date
+	 */
 	public String getAccountExpirationDateView() {
 		return timestampToDateString(accountExpirationDate);
 	}
 
+	/**
+	 * Sets the timestamp when the user account expires. Login will not be allowed afterward.
+	 *
+	 * @param accountExpirationDate
+	 *            account expiration date
+	 */
 	public void setAccountExpirationDate(Date accountExpirationDate) {
 		this.accountExpirationDate = accountExpirationDate;
 	}
 
+	/**
+	 * Gets the timestamp when the user's credentials expire and must be reset.
+	 *
+	 * @return timestamp when credentials expire
+	 */
 	public Date getCredentialsExpirationDate() {
 		return credentialsExpirationDate;
 	}
 
+	/**
+	 * Gets a string representation of the day when the user's credentials expire.
+	 *
+	 * @return stringified credential expiration date
+	 */
 	public String getCredentialsExpirationDateView() {
 		return timestampToDateString(credentialsExpirationDate);
 	}
 
+	/**
+	 * Sets the timestamp when the user's credentials expire and must be reset.
+	 *
+	 * @param credentialsExpirationDate
+	 *            timestamp when credentials expire
+	 */
 	public void setCredentialsExpirationDate(Date credentialsExpirationDate) {
 		this.credentialsExpirationDate = credentialsExpirationDate;
 	}
 
+	/**
+	 * Gets the roles assigned to the user.
+	 *
+	 * @return list of roles
+	 */
 	public List<UserRole> getUserRoles() {
 		return userRoles;
 	}
 
+	/**
+	 * Sets the roles assigned to the user.
+	 *
+	 * @param userRoles
+	 *            list of roles
+	 */
 	public void setUserRoles(List<UserRole> userRoles) {
 		this.userRoles = userRoles;
 	}
 
+	/**
+	 * Gets the method used to authenticate the account.
+	 *
+	 * @see AuthenticationMethod
+	 * @return method used to authenticate the account
+	 */
 	public AuthenticationMethod getAuthenticationMethod() {
 		return this.authenticationMethod;
 	}
 
+	/**
+	 * Sets the method used to authenticate the account.
+	 *
+	 * @see AuthenticationMethod
+	 * @param authenticationMethod
+	 *            method used to authenticate the account
+	 */
 	public void setAuthenticationMethod(AuthenticationMethod authenticationMethod) {
 		this.authenticationMethod = authenticationMethod;
 	}
 
+	/**
+	 * Gets whether the account is authenticated using LDAP.
+	 *
+	 * @see #isLdapUser()
+	 * @see #getAuthenticationMethod()
+	 * @return true if the authentication method is {@link AuthenticationMethod#LDAP}, false if not
+	 */
 	public boolean getLdapUser() {
 		return AuthenticationMethod.LDAP.equals(authenticationMethod);
 	}
 
+	/**
+	 * Gets whether the account is authenticated using LDAP.
+	 *
+	 * @see #getLdapUser()
+	 * @see #getAuthenticationMethod()
+	 * @return true if the authentication method is {@link AuthenticationMethod#LDAP}, false if not
+	 */
 	public boolean isLdapUser() {
 		return this.getLdapUser();
 	}
 
+	/**
+	 * Gets whether the account is authenticated using table-based authentication.
+	 *
+	 * @see #getAuthenticationMethod()
+	 * @return true if the authentication method is {@link AuthenticationMethod#TABLE_BASED}, false if not
+	 */
 	public boolean isTableBasedUser() {
 		return AuthenticationMethod.TABLE_BASED.equals(authenticationMethod);
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/UserRole.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/UserRole.java
@@ -19,37 +19,79 @@ import jakarta.validation.constraints.Size;
 @Entity
 public class UserRole extends AbstractEntity implements Labelled, Comparable<UserRole> {
 
+	/**
+	 * The name of the role. Must be unique.
+	 */
 	@NotNull
 	@Column(unique = true)
 	private String roleName;
 
+	/**
+	 * A description of the role.
+	 */
 	@NotNull
 	@Size(max = 50)
 	private String description;
 
+	/**
+	 * Users who have been granted the role.
+	 */
 	@ManyToMany(mappedBy = "userRoles")
 	private List<User> users;
 
+	/**
+	 * Gets the name of the role.
+	 * 
+	 * @return the role name
+	 */
 	public String getRoleName() {
 		return roleName;
 	}
 
+	/**
+	 * Sets the name of the role.
+	 * 
+	 * @param roleName
+	 *            the role name
+	 */
 	public void setRoleName(String roleName) {
 		this.roleName = roleName;
 	}
 
+	/**
+	 * Gets the description of the role.
+	 * 
+	 * @return description of the role
+	 */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 * Sets the description of the role.
+	 * 
+	 * @param description
+	 *            description of the role
+	 */
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
+	/**
+	 * Gets the list of users who have been granted the role.
+	 * 
+	 * @return list of users
+	 */
 	public List<User> getUsers() {
 		return users;
 	}
 
+	/**
+	 * Sets the list of users who have been granted the role.
+	 * 
+	 * @param users
+	 *            list of users
+	 */
 	public void setUsers(List<User> users) {
 		this.users = users;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/UserUserRole.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/UserUserRole.java
@@ -19,17 +19,34 @@ import jakarta.validation.constraints.NotNull;
 @Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "user_role", "user" }) })
 public class UserUserRole extends AbstractEntity {
 
+	/**
+	 * The user role assigned.
+	 */
 	@NotNull
 	@ManyToOne
 	private UserRole userRole;
 
+	/**
+	 * The user granted the role.
+	 */
 	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	private User user;
 
+	/**
+	 * Default constructor.
+	 */
 	public UserUserRole() {
 	}
 
+	/**
+	 * Constructor.
+	 * 
+	 * @param user
+	 *            the user granted the role
+	 * @param userRole
+	 *            the role being granted
+	 */
 	public UserUserRole(User user, UserRole userRole) {
 		Assert.notNull(user, "user may not be null");
 		Assert.notNull(userRole, "userRole may not be null");
@@ -38,18 +55,40 @@ public class UserUserRole extends AbstractEntity {
 		this.userRole = userRole;
 	}
 
+	/**
+	 * Gets the role granted to the user.
+	 * 
+	 * @return the role granted
+	 */
 	public UserRole getUserRole() {
 		return this.userRole;
 	}
 
+	/**
+	 * Sets the role granted to the user.
+	 * 
+	 * @param userRole
+	 *            the role granted
+	 */
 	public void setUserRole(UserRole userRole) {
 		this.userRole = userRole;
 	}
 
+	/**
+	 * Gets the user granted the role.
+	 * 
+	 * @return the user
+	 */
 	public User getUser() {
 		return this.user;
 	}
 
+	/**
+	 * Sets the user being granted the role.
+	 * 
+	 * @param user
+	 *            the user
+	 */
 	public void setUser(User user) {
 		this.user = user;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/DuplicateEmailException.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/DuplicateEmailException.java
@@ -9,25 +9,62 @@ public class DuplicateEmailException extends UserManagementException {
 
 	private static final long serialVersionUID = 1L;
 
-	// This message is presented to users.
+	/**
+	 * This message is presented to users.
+	 */
 	public static final String DUPLICATE_EMAIL_MESSAGE = "The provided email is already in use.";
 
+	/**
+	 * Default constructor. Uses {@link #DUPLICATE_EMAIL_MESSAGE} as the error message.
+	 */
 	public DuplicateEmailException() {
 		super(DUPLICATE_EMAIL_MESSAGE);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message.
+	 * 
+	 * @param message
+	 *            custom error message
+	 */
 	public DuplicateEmailException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an exception with the default {@link #DUPLICATE_EMAIL_MESSAGE} error message and the given cause.
+	 * 
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public DuplicateEmailException(Throwable cause) {
 		super(DUPLICATE_EMAIL_MESSAGE, cause);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message and cause.
+	 * 
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public DuplicateEmailException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructs an exception with all fields overridden.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 * @param enableSuppression
+	 *            whether suppression is enabled
+	 * @param writableStackTrace
+	 *            whether the stack trace should be writable
+	 */
 	public DuplicateEmailException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/InvalidLdapUserDetailsException.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/InvalidLdapUserDetailsException.java
@@ -10,25 +10,62 @@ public class InvalidLdapUserDetailsException extends UserManagementException {
 
 	private static final long serialVersionUID = 1L;
 
-	// This message is presented to users.
+	/**
+	 * This message is presented to users.
+	 */
 	public static final String INVALID_USER_DETAILS_MESSAGE = "The provided email does not match the one in LDAP. You may use the 'LDAP Lookup' button to populate the user details.";
 
+	/**
+	 * Default constructor. Uses {@link #INVALID_USER_DETAILS_MESSAGE} as the error message.
+	 */
 	public InvalidLdapUserDetailsException() {
 		super(INVALID_USER_DETAILS_MESSAGE);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message.
+	 *
+	 * @param message
+	 *            custom error message
+	 */
 	public InvalidLdapUserDetailsException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an exception with the default {@link #INVALID_USER_DETAILS_MESSAGE} error message and the given cause.
+	 *
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public InvalidLdapUserDetailsException(Throwable cause) {
 		super(INVALID_USER_DETAILS_MESSAGE, cause);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message and cause.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public InvalidLdapUserDetailsException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructs an exception with all fields overridden.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 * @param enableSuppression
+	 *            whether suppression is enabled
+	 * @param writableStackTrace
+	 *            whether the stack trace should be writable
+	 */
 	public InvalidLdapUserDetailsException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/InvalidPasswordException.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/InvalidPasswordException.java
@@ -2,28 +2,63 @@ package org.octri.authentication.server.security.exception;
 
 /**
  * An exception for marking invalid passwords.
- * 
+ *
  * @author sams
  */
 public class InvalidPasswordException extends Exception {
 
 	private static final long serialVersionUID = -2066695845899054899L;
 
+	/**
+	 * Default constructor.
+	 */
 	public InvalidPasswordException() {
 	}
 
+	/**
+	 * Constructs an exception with a custom error message.
+	 *
+	 * @param message
+	 *            custom error message
+	 */
 	public InvalidPasswordException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an exception with the default (empty) error message and the given cause.
+	 *
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public InvalidPasswordException(Throwable cause) {
 		super(cause);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message and cause.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public InvalidPasswordException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructs an exception with all fields overridden.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 * @param enableSuppression
+	 *            whether suppression is enabled
+	 * @param writableStackTrace
+	 *            whether the stack trace should be writable
+	 */
 	public InvalidPasswordException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/UserDirectorySearchException.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/UserDirectorySearchException.java
@@ -5,24 +5,62 @@ package org.octri.authentication.server.security.exception;
  */
 public class UserDirectorySearchException extends UserManagementException {
 
+	/**
+	 * This message is presented to users.
+	 */
 	private static final String NOT_IN_LDAP_MESSAGE = "The username provided could not be found in LDAP.";
 
+	/**
+	 * Constructs an exception with the default message.
+	 */
 	public UserDirectorySearchException() {
 		super(NOT_IN_LDAP_MESSAGE);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message.
+	 *
+	 * @param message
+	 *            custom error message
+	 */
 	public UserDirectorySearchException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an exception with the default error message and the given cause.
+	 *
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public UserDirectorySearchException(Throwable cause) {
 		super(NOT_IN_LDAP_MESSAGE, cause);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message and cause.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public UserDirectorySearchException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructs an exception with all fields overridden.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 * @param enableSuppression
+	 *            whether suppression is enabled
+	 * @param writableStackTrace
+	 *            whether the stack trace should be writable
+	 */
 	public UserDirectorySearchException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/UserManagementException.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/exception/UserManagementException.java
@@ -5,24 +5,62 @@ package org.octri.authentication.server.security.exception;
  */
 public class UserManagementException extends Exception {
 
+	/**
+	 * This message is presented to users.
+	 */
 	private static final String GENERIC_MESSAGE = "An unexpected user management error has occurred. Please contact an administrator.";
 
+	/**
+	 * Constructs an exception with the default message.
+	 */
 	public UserManagementException() {
 		super(GENERIC_MESSAGE);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message.
+	 *
+	 * @param message
+	 *            custom error message
+	 */
 	public UserManagementException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an exception with the default error message and the given cause.
+	 *
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public UserManagementException(Throwable cause) {
 		super(cause);
 	}
 
+	/**
+	 * Constructs an exception with a custom error message and cause.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 */
 	public UserManagementException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructs an exception with all fields overridden.
+	 *
+	 * @param message
+	 *            custom error message
+	 * @param cause
+	 *            the exception that caused the new exception to be thrown
+	 * @param enableSuppression
+	 *            whether suppression is enabled
+	 * @param writableStackTrace
+	 *            whether the stack trace should be writable
+	 */
 	public UserManagementException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/Messages.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/Messages.java
@@ -5,20 +5,44 @@ package org.octri.authentication.server.security.password;
  */
 public class Messages {
 
+	/**
+	 * The header displayed when changing the user's password.
+	 */
 	public static final String TITLE_CHANGE_PASSWORD = "Change Password";
 
+	/**
+	 * The header displayed when resetting the user's password.
+	 */
 	public static final String TITLE_RESET_PASSWORD = "Reset Password";
 
+	/**
+	 * Error message displayed when a user's password may not be reset (e.g. LDAP accounts).
+	 */
 	public static final String INVALID_PASSWORD_RESET = "Your password cannot be reset. Please contact an administrator for assistance.";
-	
+
+	/**
+	 * Error message displayed when a password does not pass complexity validation.
+	 */
 	public static final String PASSWORD_INVALID = "The password does not meet all of the requirements.";
 
+	/**
+	 * Error message displayed when a password is too short.
+	 */
 	public static final String PASSWORD_TOO_SHORT = "Password too short.";
 
+	/**
+	 * Error message displayed when passwords must contain a digit, but a digit is not present.
+	 */
 	public static final String PASSWORD_INSUFFICIENT_DIGIT = "Missing a number.";
 
+	/**
+	 * Error message displayed when passwords must contain a capital letter, but one is not present.
+	 */
 	public static final String PASSWORD_INSUFFICIENT_UPPERCASE = "Missing a capital letter.";
 
+	/**
+	 * Error message displayed when passwords must contain a special character, but one is not present.
+	 */
 	public static final String PASSWORD_INSUFFICIENT_SPECIAL = "Missing a special character.";
 
 	/**
@@ -27,18 +51,39 @@ public class Messages {
 	 */
 	public static final String PASSWORD_INSUFFICIENT_CHARACTERISTICS = "Missing an additional capital letter OR a special character.";
 
+	/**
+	 * Error message that is displayed when a user tries to reuse their current password.
+	 */
 	public static final String MUST_NOT_USE_CURRENT_PASSWORD = "Must not use current password";
 
+	/**
+	 * Error message that is displayed when a user tries to use a password containing their username.
+	 */
 	public static final String PASSWORDS_MUST_NOT_INCLUDE_USERNAME = "Passwords must not include username";
 
+	/**
+	 * Error message that is displayed if the new password and password confirmation fields do not match.
+	 */
 	public static final String NEW_AND_CONFIRM_PASSWORDS_MISMATCH = "New and Confirm passwords don't match.";
 
+	/**
+	 * Error message that is displayed when a user is changing their password, and their current password is incorrect.
+	 */
 	public static final String CURRENT_PASSWORD_INCORRECT = "Current password incorrect.";
 
+	/**
+	 * Error message that is displayed if the user cannot be found.
+	 */
 	public static final String COULD_NOT_FIND_AN_EXISTING_USER = "Could not find an existing user.";
 
+	/**
+	 * Error displayed if the username is not present in the session.
+	 */
 	public static final String COULD_NOT_FIND_USERNAME_IN_SESSION = "Could not find username in session.";
 
+	/**
+	 * Generic error message.
+	 */
 	public static final String DEFAULT_ERROR_MESSAGE = "An error occurred. If this continues please contact your administrator.";
 
 	private Messages() {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/PasswordConstraintValidator.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/PasswordConstraintValidator.java
@@ -21,9 +21,9 @@ import jakarta.validation.ConstraintValidatorContext;
 /**
  * A password constraint validator. Validates passwords against OHSU standards.
  *
- * @see https://ozone.ohsu.edu/cc/sec/isp/00004.pdf
- * @see http://www.passay.org/reference/
- * @see http://www.baeldung.com/registration-password-strength-and-rules
+ * @see <a href="http://www.passay.org/reference/">Passay reference documentation</a>
+ * @see <a href="http://www.baeldung.com/registration-password-strength-and-rules">baeldung.com - Password Strength and
+ *      Rules</a>
  * @author sams
  */
 @Component
@@ -35,8 +35,10 @@ public class PasswordConstraintValidator {
 	 * Get a list of validation error messages, or an empty list if the password passes validation.
 	 *
 	 * @param password
+	 *            password value
 	 * @param context
-	 * @return
+	 *            constraint validation context
+	 * @return a list of validation errors, ar an empty list if the password passes validation
 	 */
 	public List<String> validate(String password, ConstraintValidatorContext context) {
 		// Require at least one capital letter

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/PasswordGenConfig.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/PasswordGenConfig.java
@@ -6,12 +6,12 @@ import org.springframework.stereotype.Component;
 /**
  * Configuration class for allowing admins to generate temporary passwords. This class can be used to disable the
  * feature or to configure the properties of a password.
- * 
+ *
  * TODO: Allow configuration of an encoded string used to specify the password format.
- * See @link{StructuredPasswordGenerator} Components. Each component should have a string representation and the format
+ * See {@link StructuredPasswordGenerator} Components. Each component should have a string representation and the format
  * string should be parsed to construct a component list.
- * 
- * 
+ *
+ *
  * @author lawhead
  *
  */
@@ -28,50 +28,118 @@ public class PasswordGenConfig {
 	// Encoded String; see {@link StructuredPasswordGenerator#setFormat}
 	private String format;
 
+	/**
+	 * Gets whether password generation is enabled.
+	 *
+	 * @return true if password generation is enabled, false otherwise
+	 */
 	public Boolean getEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Sets whether to enable password generation.
+	 *
+	 * @param enabled
+	 *            true to enable password generation, false if not
+	 */
 	public void setEnabled(Boolean enabled) {
 		this.enabled = enabled;
 	}
 
+	/**
+	 * Gets the filename of the dictionary file.
+	 *
+	 * @return filename of the dictionary file
+	 */
 	public String getDictionaryFile() {
 		return dictionaryFile;
 	}
 
+	/**
+	 * Sets the filename of the dictionary file.
+	 *
+	 * @param dictionaryFile
+	 *            filename of the dictionary file to use
+	 */
 	public void setDictionaryFile(String dictionaryFile) {
 		this.dictionaryFile = dictionaryFile;
 	}
 
+	/**
+	 * Gets the minimum word length allowed.
+	 *
+	 * @return the minimum allowed word length
+	 */
 	public Integer getMinWordLength() {
 		return minWordLength;
 	}
 
+	/**
+	 * Sets the minimum word length allowed.
+	 *
+	 * @param minWordLength
+	 *            the minimum word length to allow
+	 */
 	public void setMinWordLength(Integer minWordLength) {
 		this.minWordLength = minWordLength;
 	}
 
+	/**
+	 * Gets the maximum word length allowed.
+	 *
+	 * @return the maximum allowed word length
+	 */
 	public Integer getMaxWordLength() {
 		return maxWordLength;
 	}
 
+	/**
+	 * Sets the maximum word length allowed.
+	 *
+	 * @param maxWordLength
+	 *            the maximum word length to allow
+	 */
 	public void setMaxWordLength(Integer maxWordLength) {
 		this.maxWordLength = maxWordLength;
 	}
 
+	/**
+	 * Gets the string used to join the words in generated passwords.
+	 *
+	 * @return the separator character
+	 */
 	public String getSeparator() {
 		return separator;
 	}
 
+	/**
+	 * Sets the string used to join the words in generated passwords.
+	 *
+	 * @param separator
+	 *            the separator character to use
+	 */
 	public void setSeparator(String separator) {
 		this.separator = separator;
 	}
 
+	/**
+	 * Gets the password format string.
+	 *
+	 * @see StructuredPasswordGenerator#setFormat(String)
+	 * @return the password format string
+	 */
 	public String getFormat() {
 		return format;
 	}
 
+	/**
+	 * Sets the password format string used.
+	 *
+	 * @see StructuredPasswordGenerator#setFormat(String)
+	 * @param format
+	 *            the format to use
+	 */
 	public void setFormat(String format) {
 		this.format = format;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/RandomDictionary.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/RandomDictionary.java
@@ -24,6 +24,7 @@ public class RandomDictionary {
 	 * Create a new dictionary from the given wordlist.
 	 *
 	 * @param wordList
+	 *            list of words to include in the dictionary
 	 */
 	public RandomDictionary(List<String> wordList) {
 		Assert.notNull(wordList, "Wordlist must not be null");
@@ -35,8 +36,10 @@ public class RandomDictionary {
 	 * Get a random word from the dictionary with a length between minSize and maxSize inclusive.
 	 *
 	 * @param minSize
+	 *            minimum length of the selected word
 	 * @param maxSize
-	 * @return
+	 *            maximum length of the selected word
+	 * @return a random word with length between minSize and maxSize
 	 */
 	public String getRandom(int minSize, int maxSize) {
 
@@ -59,8 +62,10 @@ public class RandomDictionary {
 	}
 
 	/**
-	 *
+	 * Gets the number of words in the dictionary with the given length.
+	 * 
 	 * @param size
+	 *            the size of word to search for
 	 * @return number of words of a given length; useful for calculating password entropy.
 	 */
 	public Integer wordsOfLength(int size) {
@@ -68,9 +73,12 @@ public class RandomDictionary {
 	}
 
 	/**
-	 *
+	 * Gets the number of words in the dictionary that have a length in the given range.
+	 * 
 	 * @param minSize
+	 *            minimum word length
 	 * @param maxSize
+	 *            maximum word length
 	 * @return number of words in a given length range (inclusive)
 	 */
 	public Integer wordsInRange(int minSize, int maxSize) {
@@ -84,9 +92,10 @@ public class RandomDictionary {
 	}
 
 	/**
-	 * Given the wordlist, initialize the underlying data structure.
+	 * Given the word list, initialize the underlying data structure.
 	 *
 	 * @param wordList
+	 *            list of words
 	 */
 	private void initialize(List<String> wordList) {
 		wordsBySize = new HashMap<>();
@@ -97,10 +106,21 @@ public class RandomDictionary {
 		}
 	}
 
+	/**
+	 * Gets the maximum number of times the dictionary will attempt to find a word of the requested size.
+	 * 
+	 * @return the maximum number of attempts
+	 */
 	public Integer getMaxAttempts() {
 		return maxAttempts;
 	}
 
+	/**
+	 * Sets the maximum number of times the dictionary will attempt to find a word of the requested size.
+	 * 
+	 * @param attempts
+	 *            the desired number of attempts
+	 */
 	public void setMaxAttempts(Integer attempts) {
 		this.maxAttempts = attempts;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/Reason.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/Reason.java
@@ -8,24 +8,48 @@ import org.passay.PasswordValidator;
 public class Reason {
 
 	/**
-	 * These keys are produced by the {@link PasswordValidator}. See
-	 * {@link https://github.com/vt-middleware/passay/blob/0f107af039e1bf4e617a65287f7c3d6199094ce8/src/main/resources/messages.properties}
-	 * for a full list.
+	 * These keys are produced by the {@link PasswordValidator}. See <a href=
+	 * "https://github.com/vt-middleware/passay/blob/0f107af039e1bf4e617a65287f7c3d6199094ce8/src/main/resources/messages.properties">the
+	 * Passay messages.properties file</a> * for a full list.
 	 *
 	 * @author sams
 	 */
 	public enum ReasonKey {
-		TOO_SHORT, INSUFFICIENT_DIGIT, INSUFFICIENT_UPPERCASE, INSUFFICIENT_SPECIAL, INSUFFICIENT_CHARACTERISTICS;
+		/**
+		 * Indicates the password is too short
+		 */
+		TOO_SHORT,
+
+		/**
+		 * Indicates the password contains too few digit characters
+		 */
+		INSUFFICIENT_DIGIT,
+
+		/**
+		 * Indicates the password contains too few uppercase characters
+		 */
+		INSUFFICIENT_UPPERCASE,
+
+		/**
+		 * Indicates the password contains too few special characters
+		 */
+		INSUFFICIENT_SPECIAL,
+
+		/**
+		 * Indicates either {@link #INSUFFICIENT_UPPERCASE} or {@link #INSUFFICIENT_SPECIAL}
+		 */
+		INSUFFICIENT_CHARACTERISTICS;
 	}
 
 	/**
 	 * Returns a message to be displayed to the user when a password fails validation.
 	 *
 	 * @param key
+	 *            a message key
 	 * @return The message as a String.
 	 */
 	public static String message(final String key) {
-		
+
 		try {
 			switch (ReasonKey.valueOf(key)) {
 				case TOO_SHORT:
@@ -42,10 +66,11 @@ public class Reason {
 					return Messages.PASSWORD_INVALID;
 			}
 		} catch (IllegalArgumentException ex) {
-			// On occasion we'll encounter reasons we haven't handled in the enum. Return a generic message instead of throwing an exception.
+			// On occasion we'll encounter reasons we haven't handled in the enum. Return a generic message instead of
+			// throwing an exception.
 			return Messages.PASSWORD_INVALID;
 		}
-		
+
 	}
 
 	private Reason() {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/password/StructuredPasswordGenerator.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/password/StructuredPasswordGenerator.java
@@ -9,31 +9,67 @@ import org.springframework.util.Assert;
 
 /**
  * Password Generator that generates passwords following a given structure.
- * 
+ *
  * @author lawhead
  *
  */
 public class StructuredPasswordGenerator {
 
+	/**
+	 * Password format components
+	 */
 	public enum Component {
-		CAPITAL_WORD('C'), WORD('W'), DIGIT('D'), SPECIAL('S'), MY_SYMBOL('M');
+
+		/**
+		 * A word with the first letter capitalized
+		 */
+		CAPITAL_WORD('C'),
+
+		/**
+		 * A lowercase word
+		 */
+		WORD('W'),
+
+		/**
+		 * A digit character
+		 */
+		DIGIT('D'),
+
+		/**
+		 * A special character
+		 */
+		SPECIAL('S'),
+
+		/**
+		 * A symbol character
+		 */
+		MY_SYMBOL('M');
 
 		private Character code;
 
-		// Constructor
+		/**
+		 * Constructor.
+		 *
+		 * @param code
+		 *            character code used to represent the component
+		 */
 		Component(Character code) {
 			this.code = code;
 		}
 
+		/**
+		 * @return the character code used to represent the component
+		 */
 		public Character getCode() {
 			return code;
 		}
 
 		/**
 		 * Find Component by its format code.
-		 * 
+		 *
 		 * @param code
-		 * @return
+		 *            character code
+		 * @return the component represented by the code, or null if no component is represented by it
 		 */
 		public static Component fromCode(Character code) {
 
@@ -60,7 +96,7 @@ public class StructuredPasswordGenerator {
 
 	/**
 	 * Construct a new Generator using the provided dictionary.
-	 * 
+	 *
 	 * @param dictionary
 	 *            - dictionary used to retrieve random words.
 	 */
@@ -70,8 +106,8 @@ public class StructuredPasswordGenerator {
 
 	/**
 	 * Generate a random password using the configured format.
-	 * 
-	 * @return
+	 *
+	 * @return a random password in the configured format
 	 */
 	public String generate() {
 		return generate(this.format);
@@ -79,9 +115,10 @@ public class StructuredPasswordGenerator {
 
 	/**
 	 * Generate a random password using the provided format.
-	 * 
+	 *
 	 * @param format
-	 * @return
+	 *            format string
+	 * @return a random password matching the given format
 	 */
 	public String generate(List<Component> format) {
 		StringBuffer buf = new StringBuffer();
@@ -103,7 +140,6 @@ public class StructuredPasswordGenerator {
 	}
 
 	/**
-	 * 
 	 * @return a random digit (0 - 9)
 	 */
 	private Integer randomDigit() {
@@ -111,7 +147,6 @@ public class StructuredPasswordGenerator {
 	}
 
 	/**
-	 * 
 	 * @return a random special character
 	 */
 	private Character randomSymbol() {
@@ -139,50 +174,107 @@ public class StructuredPasswordGenerator {
 	}
 
 	// Accessors
+
+	/**
+	 * Gets the minimum length of selected words.
+	 *
+	 * @return the minimum length
+	 */
 	public Integer getMinWordLength() {
 		return minWordLength;
 	}
 
+	/**
+	 * Sets the minimum length of selected words.
+	 *
+	 * @param minWordLength
+	 *            the minimum length
+	 */
 	public void setMinWordLength(Integer minWordLength) {
 		this.minWordLength = minWordLength;
 	}
 
+	/**
+	 * Gets the maximum length of selected words.
+	 *
+	 * @return the maximum length
+	 */
 	public Integer getMaxWordLength() {
 		return maxWordLength;
 	}
 
+	/**
+	 * Sets the maximum length of selected words.
+	 *
+	 * @param maxWordLength
+	 *            the maximum length
+	 */
 	public void setMaxWordLength(Integer maxWordLength) {
 		this.maxWordLength = maxWordLength;
 	}
 
+	/**
+	 * Gets the symbol string used a separator.
+	 *
+	 * @return the symbol string
+	 */
 	public String getSymbol() {
 		return symbol;
 	}
 
+	/**
+	 * Sets the symbol string used a separator.
+	 *
+	 * @param sym
+	 *            the symbol string
+	 */
 	public void setSymbol(String sym) {
 		this.symbol = sym;
 	}
 
+	/**
+	 * Gets the dictionary of words used.
+	 *
+	 * @return dictionary of words used
+	 */
 	public RandomDictionary getDictionary() {
 		return dictionary;
 	}
 
+	/**
+	 * Sets the dictionary of words used.
+	 *
+	 * @param dictionary
+	 *            dictionary of words used
+	 */
 	public void setDictionary(RandomDictionary dictionary) {
 		this.dictionary = dictionary;
 	}
 
+	/**
+	 * Gets the format of generated passwords as a list of password components.
+	 *
+	 * @return password format
+	 */
 	public List<Component> getFormat() {
 		return format;
 	}
 
+	/**
+	 * Sets the format of generated passwords as a list of password components.
+	 *
+	 * @param format
+	 *            password format
+	 */
 	public void setFormat(List<Component> format) {
 		this.format = format;
 	}
 
 	/**
 	 * Set the format from an encoded string; see the Component enumeration for valid codes.
-	 * 
+	 *
 	 * @param encodedFormat
+	 *            password format string
 	 */
 	public void setFormat(String encodedFormat) {
 		List<Component> components = new ArrayList<>();
@@ -197,10 +289,21 @@ public class StructuredPasswordGenerator {
 		this.setFormat(components);
 	}
 
+	/**
+	 * Gets the list of special characters used, as a string. Default is "!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~".
+	 *
+	 * @return special character string
+	 */
 	public String getSpecialChars() {
 		return specialChars;
 	}
 
+	/**
+	 * Sets the list of special characters used, as a string. Default is "!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~".
+	 *
+	 * @param specialChars
+	 *            special character string
+	 */
 	public void setSpecialChars(String specialChars) {
 		this.specialChars = specialChars;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/PasswordResetTokenRepository.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/PasswordResetTokenRepository.java
@@ -13,9 +13,30 @@ import org.springframework.data.repository.query.Param;
  */
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
 
+	/**
+	 * Finds a password reset token by its token string.
+	 *
+	 * @param token
+	 *            token string to search by
+	 * @return the record with the given token string, or null
+	 */
 	public PasswordResetToken findByToken(@Param("token") String token);
 
+	/**
+	 * Finds the reset token with the latest expiration date associated with the given user ID.
+	 *
+	 * @param userId
+	 *            user ID to search by
+	 * @return the latest reset token for the given user ID if there is one, empty otherwise
+	 */
 	public Optional<PasswordResetToken> findFirstByUserIdOrderByExpiryDateDesc(Long userId);
 
+	/**
+	 * Finds reset tokens that expire after the given date.
+	 *
+	 * @param expiryDate
+	 *            the date tokens should expire after
+	 * @return all tokens that expire after the given date, in descending order of expiration date
+	 */
 	public List<PasswordResetToken> findByExpiryDateGreaterThanOrderByExpiryDateDesc(Date expiryDate);
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/SessionEventRepository.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/SessionEventRepository.java
@@ -11,6 +11,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface SessionEventRepository extends JpaRepository<SessionEvent, Long> {
 
+	/**
+	 * Finds an event by session ID and event type.
+	 * 
+	 * @param sessionId
+	 *            session ID
+	 * @param eventType
+	 *            event type
+	 * @return a session event if an event of the given type exists for the given session, otherwise empty
+	 */
 	Optional<SessionEvent> findFirstBySessionIdAndEvent(String sessionId, EventType eventType);
 
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserRepository.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserRepository.java
@@ -6,14 +6,28 @@ import org.springframework.data.repository.query.Param;
 
 /**
  * {@link JpaRepository} for manipulating {@link User} entities.
- * 
+ *
  * @author harrelst
  *
  */
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	/**
+	 * Finds a user by their username.
+	 * 
+	 * @param username
+	 *            username to search by
+	 * @return the user with the given username, or null if not found
+	 */
 	public User findByUsername(@Param("username") String username);
 
+	/**
+	 * Finds a user by their email address.
+	 * 
+	 * @param email
+	 *            email address to search by
+	 * @return the user with the given email address, or null if not found
+	 */
 	public User findByEmail(@Param("email") String email);
 
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserRoleRepository.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserRoleRepository.java
@@ -12,5 +12,12 @@ import org.springframework.data.repository.query.Param;
  */
 public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
 
+	/**
+	 * Finds a role by its name.
+	 * 
+	 * @param roleName
+	 *            role name
+	 * @return the role with the given name, or null if no role matches
+	 */
 	public UserRole findByRoleName(@Param("roleName") String roleName);
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserUserRoleRepository.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/repository/UserUserRoleRepository.java
@@ -6,14 +6,20 @@ import org.octri.authentication.server.security.entity.User;
 import org.octri.authentication.server.security.entity.UserUserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-
 /**
  * {@link JpaRepository} for manipulating {@link UserUserRole} entities.
- * 
+ *
  * @author yateam
  *
  */
 public interface UserUserRoleRepository extends JpaRepository<UserUserRole, Long> {
 
+	/**
+	 * Finds user role grants for the given user.
+	 * 
+	 * @param user
+	 *            user account
+	 * @return the user's user role grants
+	 */
 	public List<UserUserRole> findByUser(User user);
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/ApplicationSaml2AuthenticatedPrincipal.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/ApplicationSaml2AuthenticatedPrincipal.java
@@ -9,6 +9,7 @@ import org.octri.authentication.server.security.entity.User;
 import org.opensaml.saml.saml2.core.NameID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 
 /**
  * Custom implementation of {@link Saml2AuthenticatedPrincipal} with additional user details. Captures NameID values
@@ -19,18 +20,48 @@ public class ApplicationSaml2AuthenticatedPrincipal extends AuthenticationUserDe
 
 	private static final long serialVersionUID = -7394856325865885172L;
 
+	/**
+	 * The NameID the SAML IdP used to identify the user.
+	 */
 	private final NameID nameId;
 
+	/**
+	 * Attributes included in the SAML assertion.
+	 */
 	private final Map<String, List<Object>> attributes;
 
+	/**
+	 * ID of the relying party registration that authenticated the user.
+	 */
 	private String relyingPartyRegistrationId;
 
+	/**
+	 * The user's first name (given name).
+	 */
 	private String firstName;
 
+	/**
+	 * The user's last name (family name, surname).
+	 */
 	private String lastName;
 
+	/**
+	 * The user's email address.
+	 */
 	private String email;
 
+	/**
+	 * Constructor
+	 *
+	 * @param user
+	 *            user entity
+	 * @param authorities
+	 *            the user's authorities (e.g. roles)
+	 * @param nameId
+	 *            the SAML NameID provided by the IdP
+	 * @param attributes
+	 *            attributes included in the SAML assertion
+	 */
 	public ApplicationSaml2AuthenticatedPrincipal(User user, Collection<? extends GrantedAuthority> authorities,
 			NameID nameId, Map<String, List<Object>> attributes) {
 		super(user, authorities);
@@ -42,49 +73,88 @@ public class ApplicationSaml2AuthenticatedPrincipal extends AuthenticationUserDe
 		this.relyingPartyRegistrationId = null;
 	}
 
+	/**
+	 * Returns the authenticated principal's username.
+	 */
 	@Override
 	public String getName() {
 		return this.getUsername();
 	}
 
+	/**
+	 * Returns attributes included in the SAML assertion.
+	 */
 	@Override
 	public Map<String, List<Object>> getAttributes() {
 		return this.attributes;
 	}
 
+	/**
+	 * Returns the ID of the {@link RelyingPartyRegistration} associated with the login request.
+	 */
 	@Override
 	public String getRelyingPartyRegistrationId() {
 		return this.relyingPartyRegistrationId;
 	}
 
+	/**
+	 * Sets the ID of the {@link RelyingPartyRegistration} associated with the login request.
+	 *
+	 * @param relyingPartyRegistrationId
+	 *            string identifying the {@link RelyingPartyRegistration}
+	 */
 	public void setRelyingPartyRegistrationId(String relyingPartyRegistrationId) {
 		this.relyingPartyRegistrationId = relyingPartyRegistrationId;
 	}
 
+	/**
+	 * @return the NameID the SAML IdP used to identify the user
+	 */
 	public NameID getNameId() {
 		return this.nameId;
 	}
 
+	/**
+	 * @return the user's first name
+	 */
 	public String getFirstName() {
 		return firstName;
 	}
 
+	/**
+	 * @param firstName
+	 *            the user's first name
+	 */
 	public void setFirstName(String firstName) {
 		this.firstName = firstName;
 	}
 
+	/**
+	 * @return the user's last name
+	 */
 	public String getLastName() {
 		return lastName;
 	}
 
+	/**
+	 * @param lastName
+	 *            the user's last name
+	 */
 	public void setLastName(String lastName) {
 		this.lastName = lastName;
 	}
 
+	/**
+	 * @return the user's email address
+	 */
 	public String getEmail() {
 		return email;
 	}
 
+	/**
+	 * @param email
+	 *            the user's email address
+	 */
 	public void setEmail(String email) {
 		this.email = email;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/AssertionUtils.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/AssertionUtils.java
@@ -31,7 +31,7 @@ public class AssertionUtils {
 	 *            - assertion attributes as returned by getAssertionAttributes
 	 * @param attributeKey
 	 *            - attribute key
-	 * @return
+	 * @return the attribute value
 	 */
 	public static String getAttributeValue(Map<String, List<Object>> attributes, String attributeKey) {
 		return (String) CollectionUtils.firstElement(attributes.get(attributeKey));
@@ -40,9 +40,12 @@ public class AssertionUtils {
 	/**
 	 * Extracted from Spring Security's {@link OpenSaml4AuthenticationProvider}.
 	 *
-	 * @see https://github.com/spring-projects/spring-security/blob/5.6.x/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+	 * @see <a href=
+	 *      "https://github.com/spring-projects/spring-security/blob/5.6.x/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java">OpenSaml4AuthenticationProvider
+	 *      code</a>
 	 * @param assertion
-	 * @return
+	 *            SAML assertion
+	 * @return a map containing the assertion's attributes
 	 */
 	public static Map<String, List<Object>> getAssertionAttributes(Assertion assertion) {
 		Map<String, List<Object>> attributeMap = new LinkedHashMap<>();
@@ -64,9 +67,12 @@ public class AssertionUtils {
 	/**
 	 * Extracted from Spring Security's {@link OpenSaml4AuthenticationProvider}.
 	 *
-	 * @see https://github.com/spring-projects/spring-security/blob/5.6.x/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+	 * @see <a href=
+	 *      "https://github.com/spring-projects/spring-security/blob/5.6.x/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java">OpenSaml4AuthenticatoinProvider
+	 *      code</a>
 	 * @param xmlObject
-	 * @return
+	 *            XML node
+	 * @return the node's value
 	 */
 	private static Object getXmlObjectValue(XMLObject xmlObject) {
 		if (xmlObject instanceof XSAny) {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/DatabaseUserAuthenticationConverter.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/DatabaseUserAuthenticationConverter.java
@@ -34,6 +34,16 @@ public class DatabaseUserAuthenticationConverter implements Converter<ResponseTo
 	private UserService userService;
 	private UserUserRoleService userUserRoleService;
 
+	/**
+	 * Constructor
+	 *
+	 * @param userService
+	 *            service used to fetch database user details
+	 * @param userUserRoleService
+	 *            service used to fetch database user roles
+	 * @param samlProperties
+	 *            SAML authentication configuration
+	 */
 	public DatabaseUserAuthenticationConverter(UserService userService, UserUserRoleService userUserRoleService,
 			SamlProperties samlProperties) {
 		this.samlProperties = samlProperties;

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/DatabaseUserSamlAssertionValidator.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/DatabaseUserSamlAssertionValidator.java
@@ -29,6 +29,14 @@ public class DatabaseUserSamlAssertionValidator implements Converter<AssertionTo
 	private UserService userService;
 	private SamlProperties samlProperties;
 
+	/**
+	 * Constructor
+	 * 
+	 * @param userService
+	 *            service used to fetch database user details
+	 * @param samlProperties
+	 *            SAML authentication configuration
+	 */
 	public DatabaseUserSamlAssertionValidator(UserService userService, SamlProperties samlProperties) {
 		log.debug("Constructing with userService=" + userService + " samlProperties=" + samlProperties);
 		this.userService = userService;

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/GroupMembershipSamlAssertionValidator.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/GroupMembershipSamlAssertionValidator.java
@@ -28,10 +28,19 @@ public class GroupMembershipSamlAssertionValidator implements Converter<Assertio
 
 	private SamlProperties samlProperties;
 
+	/**
+	 * Constructor
+	 * 
+	 * @param samlProperties
+	 *            SAML authentication configuration
+	 */
 	public GroupMembershipSamlAssertionValidator(SamlProperties samlProperties) {
 		this.samlProperties = samlProperties;
 	}
 
+	/**
+	 * Validates that the user is a member of the expected group.
+	 */
 	@Override
 	public Saml2ResponseValidatorResult convert(AssertionToken assertionToken) {
 		Saml2ResponseValidatorResult result = OpenSaml4AuthenticationProvider

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/SamlResponseUserDetailsAuthenticationConverter.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/saml/SamlResponseUserDetailsAuthenticationConverter.java
@@ -31,6 +31,12 @@ public class SamlResponseUserDetailsAuthenticationConverter implements Converter
 
 	private SamlProperties samlProperties;
 
+	/**
+	 * Constructor.
+	 * 
+	 * @param samlProperties
+	 *            SAML configuration properties
+	 */
 	public SamlResponseUserDetailsAuthenticationConverter(SamlProperties samlProperties) {
 		this.samlProperties = samlProperties;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/EmailNotificationService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/EmailNotificationService.java
@@ -87,7 +87,9 @@ public class EmailNotificationService {
      * Send email confirmation to user.
      *
      * @param token
+     *            the password reset token
      * @param request
+     *            servlet request
      */
     public void sendPasswordResetEmailConfirmation(final String token, final HttpServletRequest request) {
         Assert.notNull(token, "Must provide a token");

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/PasswordGeneratorService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/PasswordGeneratorService.java
@@ -37,6 +37,7 @@ public class PasswordGeneratorService {
 	 * @param authProperties
 	 *            The authentication configuration
 	 * @throws IOException
+	 *             if an error occurs when reading the dictionary file
 	 */
 	public PasswordGeneratorService(@Autowired ResourceLoader loader, @Autowired PasswordGenConfig passwordGenConfig,
 			@Autowired OctriAuthenticationProperties authProperties)
@@ -64,7 +65,7 @@ public class PasswordGeneratorService {
 	/**
 	 * Whether this service is enabled allowing generation of temporary passwords
 	 *
-	 * @return
+	 * @return true if the service is enabled
 	 */
 	public boolean isEnabled() {
 		return enabled;

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/PasswordResetTokenService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/PasswordResetTokenService.java
@@ -36,26 +36,58 @@ public class PasswordResetTokenService {
 	@Resource
 	private PasswordResetTokenRepository passwordResetTokenRepository;
 
+	/**
+	 * Finds the reset token record with the given ID.
+	 *
+	 * @param id
+	 *            the ID to search by
+	 * @return the reset token wih the given ID
+	 */
 	@Transactional(readOnly = true)
 	public PasswordResetToken find(Long id) {
 		return passwordResetTokenRepository.findById(id).get();
 	}
 
+	/**
+	 * Finds a reset token record with the given token string.
+	 *
+	 * @param token
+	 *            the token string to search by
+	 * @return the reset token with the given token string
+	 */
 	@Transactional(readOnly = true)
 	public PasswordResetToken findByToken(String token) {
 		return passwordResetTokenRepository.findByToken(token);
 	}
 
+	/**
+	 * Saves a reset token record to the database.
+	 *
+	 * @param passwordResetToken
+	 *            a reset token object
+	 * @return the persisted reset token
+	 */
 	@Transactional
 	public PasswordResetToken save(PasswordResetToken passwordResetToken) {
 		return passwordResetTokenRepository.save(passwordResetToken);
 	}
 
+	/**
+	 * Gets all of the reset tokens.
+	 *
+	 * @return a list of all reset tokens
+	 */
 	@Transactional(readOnly = true)
 	public List<PasswordResetToken> findAll() {
 		return (List<PasswordResetToken>) passwordResetTokenRepository.findAll();
 	}
 
+	/**
+	 * Deletes the reset token record with the given ID.
+	 *
+	 * @param id
+	 *            ID of the record to delete
+	 */
 	@Transactional
 	public void delete(Long id) {
 		PasswordResetToken passwordResetToken = passwordResetTokenRepository.findById(id).orElse(null);
@@ -64,6 +96,13 @@ public class PasswordResetTokenService {
 		}
 	}
 
+	/**
+	 * Finds the reset token with the latest expiration date associated with the given user ID.
+	 *
+	 * @param userId
+	 *            user ID to search by
+	 * @return latest reset token associated with the user ID, empty if none exist
+	 */
 	public Optional<PasswordResetToken> findLatest(Long userId) {
 		return passwordResetTokenRepository.findFirstByUserIdOrderByExpiryDateDesc(userId);
 	}
@@ -86,6 +125,7 @@ public class PasswordResetTokenService {
 	 * {@link OctriAuthenticationProperties}. Tokens are persisted in the database.
 	 *
 	 * @param user
+	 *            user account
 	 * @return Returns a new {@link PasswordResetToken} for the given user.
 	 */
 	public PasswordResetToken generatePasswordResetToken(final User user) {
@@ -102,7 +142,9 @@ public class PasswordResetTokenService {
 	 * in the database.
 	 *
 	 * @param user
+	 *            user account
 	 * @param tokenDuration
+	 *            how long the token should be valid
 	 * @return Returns a new {@link PasswordResetToken} for the given user.
 	 */
 	public PasswordResetToken generatePasswordResetToken(final User user, Duration tokenDuration) {
@@ -116,7 +158,7 @@ public class PasswordResetTokenService {
 	/**
 	 * Find all active tokens. The transient field 'tokenUrl' is set for use in mustache templates.
 	 *
-	 * @return
+	 * @return list of active tokens, with populated token URLs
 	 */
 	public List<PasswordResetToken> findAllActiveTokens() {
 		List<PasswordResetToken> tokens = passwordResetTokenRepository

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/SessionEventService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/SessionEventService.java
@@ -32,9 +32,10 @@ public class SessionEventService {
 
 	/**
 	 * Log {@link SessionEvent} for the currently authenticated user. Event saved to database. Session id acquired from
-	 * {@link RequestContextHolder}. Use {@link #logEvent(EventType, String)} to manually specify the session id.
+	 * {@link RequestContextHolder}. Use {@link #logEvent(EventType, String, User)} to manually specify the session id.
 	 *
 	 * @param event
+	 *            the type of event to log
 	 */
 	public void logEvent(final EventType event) {
 		final RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
@@ -53,7 +54,9 @@ public class SessionEventService {
 	 * Log {@link SessionEvent} for the currently authenticated user. Event saved to database.
 	 *
 	 * @param event
+	 *            the type of event to log
 	 * @param sessionId
+	 *            the ID of the user's session
 	 * @param asUser
 	 *            If this is an impersonation event, pass the user being impersonated
 	 */
@@ -94,6 +97,7 @@ public class SessionEventService {
 	 * Find {@link EventType#LOGIN} event for given sessionId if one exists
 	 *
 	 * @param sessionId
+	 *            user session ID
 	 * @return Login event for session id.
 	 */
 	public Optional<SessionEvent> findLoginEvent(final String sessionId) {
@@ -104,6 +108,7 @@ public class SessionEventService {
 	 * Find {@link EventType#LOGOUT} event for given sessionId if one exists.
 	 *
 	 * @param sessionId
+	 *            user session ID
 	 * @return Logout event for session id.
 	 */
 	public Optional<SessionEvent> findLogoutEvent(final String sessionId) {
@@ -113,7 +118,9 @@ public class SessionEventService {
 	/**
 	 * Find authenticated {@link User}, otherwise throw exception.
 	 *
-	 * @return
+	 * @return the authenticated user
+	 * @throws IllegalArgumentException
+	 *             if a user could not be found
 	 */
 	private User findUser() {
 		SecurityHelper helper = new SecurityHelper(SecurityContextHolder.getContext());

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/UserRoleService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/UserRoleService.java
@@ -20,26 +20,58 @@ public class UserRoleService {
 	@Resource
 	private UserRoleRepository userRoleRepository;
 
+	/**
+	 * Finds a role by ID.
+	 * 
+	 * @param id
+	 *            role ID
+	 * @return the role with the given ID
+	 */
 	@Transactional(readOnly = true)
 	public UserRole find(Long id) {
 		return userRoleRepository.findById(id).get();
 	}
 
+	/**
+	 * Finds a role by name.
+	 * 
+	 * @param roleName
+	 *            role name
+	 * @return the role with the given name
+	 */
 	@Transactional(readOnly = true)
 	public UserRole findByRoleName(String roleName) {
 		return userRoleRepository.findByRoleName(roleName);
 	}
 
+	/**
+	 * Save a role record.
+	 * 
+	 * @param userRole
+	 *            role
+	 * @return the saved role
+	 */
 	@Transactional
 	public UserRole save(UserRole userRole) {
 		return userRoleRepository.save(userRole);
 	}
 
+	/**
+	 * Finds all user roles.
+	 * 
+	 * @return list of roles
+	 */
 	@Transactional(readOnly = true)
 	public List<UserRole> findAll() {
 		return (List<UserRole>) userRoleRepository.findAll();
 	}
 
+	/**
+	 * Deletes the role with the given ID.
+	 * 
+	 * @param id
+	 *            role ID
+	 */
 	@Transactional
 	public void delete(Long id) {
 		UserRole userRole = userRoleRepository.findById(id).orElse(null);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/UserUserRoleService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/UserUserRoleService.java
@@ -24,31 +24,70 @@ public class UserUserRoleService {
 	@Resource
 	private UserUserRoleRepository userUserRoleRepository;
 
+	/**
+	 * Finds a user role grant by ID.
+	 * 
+	 * @param id
+	 *            the ID to search by
+	 * @return user role grant
+	 */
 	@Transactional(readOnly = true)
 	public UserUserRole find(Long id) {
 		return userUserRoleRepository.findById(id).get();
 	}
 
+	/**
+	 * Finds all the user's grants.
+	 * 
+	 * @param user
+	 *            user account
+	 * @return the user's grants
+	 */
 	@Transactional(readOnly = true)
 	public List<UserUserRole> findByUser(User user) {
 		return userUserRoleRepository.findByUser(user);
 	}
 
+	/**
+	 * Finds all the roles granted to the given user.
+	 * 
+	 * @param user
+	 *            user account
+	 * @return the user roles granted to the user
+	 */
 	@Transactional(readOnly = true)
 	public List<UserRole> findUserRolesByUser(User user) {
 		return findByUser(user).stream().map(uur -> uur.getUserRole()).collect(Collectors.toList());
 	}
 
+	/**
+	 * Saves a user role grant.
+	 * 
+	 * @param userUserRole
+	 *            the grant to save
+	 * @return the saved grant
+	 */
 	@Transactional
 	public UserUserRole save(UserUserRole userUserRole) {
 		return userUserRoleRepository.save(userUserRole);
 	}
 
+	/**
+	 * Finds all user role grants.
+	 * 
+	 * @return all role grants
+	 */
 	@Transactional(readOnly = true)
 	public List<UserUserRole> findAll() {
 		return (List<UserUserRole>) userUserRoleRepository.findAll();
 	}
 
+	/**
+	 * Deletes a user role grant by ID.
+	 * 
+	 * @param id
+	 *            the ID of the grant to delete
+	 */
 	@Transactional
 	public void delete(Long id) {
 		UserUserRole userUserRole = userUserRoleRepository.findById(id).orElse(null);

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/EntitySelectOption.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/EntitySelectOption.java
@@ -4,16 +4,17 @@ import java.util.Collection;
 
 /**
  * Used for UI select inputs. Wraps the choice along with its selected status.
- * 
+ *
  * @author lawhead
  *
  * @param <T>
+ *            the type of object wrapped by the option
  */
 public class EntitySelectOption<T extends Identified & Labelled> extends SelectOption<T> {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param choice
 	 *            - lookup list item
 	 * @param selected
@@ -27,7 +28,7 @@ public class EntitySelectOption<T extends Identified & Labelled> extends SelectO
 
 	/**
 	 * Constructor used for an option in a multi-select.
-	 * 
+	 *
 	 * @param choice
 	 *            - lookup list item
 	 * @param selected
@@ -39,6 +40,11 @@ public class EntitySelectOption<T extends Identified & Labelled> extends SelectO
 		this.setValue(choice.getId().toString());
 	}
 
+	/**
+	 * Gets the entity's ID
+	 * 
+	 * @return the ID value
+	 */
 	public Long getId() {
 		return this.getChoice().getId();
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumOptionList.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumOptionList.java
@@ -8,7 +8,6 @@ import java.util.stream.StreamSupport;
  * Used in mustache views for pulldown lists.
  *
  * @author lawhead
- *         TODO: move into a library
  */
 public class EnumOptionList {
 
@@ -16,9 +15,13 @@ public class EnumOptionList {
 	 * Given a collection of Enum values and the selected value, provides a list of objects that can be used directly by
 	 * mustachejs for rendering.
 	 *
+	 * @param <T>
+	 *            an enum type
 	 * @param iter
+	 *            collection of enum values
 	 * @param selected
-	 * @return
+	 *            the currently-selected value (possibly null)
+	 * @return a list with an {@link EnumSelectOption} for each enum value
 	 */
 	public static <T extends Enum<T> & Labelled> List<EnumSelectOption<T>> fromEnum(Iterable<T> iter, T selected) {
 		return StreamSupport.stream(iter.spliterator(), false)

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/OptionList.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/OptionList.java
@@ -11,6 +11,7 @@ import java.util.stream.StreamSupport;
  *
  * @author lawhead
  * @param <T>
+ *            the type of objects in the select list
  *
  */
 public class OptionList<T> {
@@ -19,9 +20,13 @@ public class OptionList<T> {
 	 * Given a Repository search result of lookups and the selected lookup item, provides a list of objects that can be
 	 * used directly by mustachejs for rendering.
 	 *
+	 * @param <T>
+	 *            a type with an ID and label
 	 * @param iter
+	 *            an iterable collection
 	 * @param selected
-	 * @return
+	 *            the current selection (may be null)
+	 * @return a list of select options for the items in the collection
 	 */
 	public static <T extends Identified & Labelled> List<EntitySelectOption<T>> fromSearch(Iterable<T> iter,
 			T selected) {
@@ -34,9 +39,13 @@ public class OptionList<T> {
 	 * Used for multi-selects. Given a Repository search result of lookups and a list of selected lookup, provides a
 	 * list of objects that can be used directly by mustachejs for rendering.
 	 *
+	 * @param <T>
+	 *            a type with an ID and a label
 	 * @param iter
+	 *            an iterable collection
 	 * @param selected
-	 * @return
+	 *            the current selections (may be empty)
+	 * @return a list of select options for the items in the collection
 	 */
 	public static <T extends Identified & Labelled> List<EntitySelectOption<T>> multiFromSearch(Iterable<T> iter,
 			Collection<T> selected) {
@@ -49,9 +58,12 @@ public class OptionList<T> {
 	 * Generates a list of integers in the given range from which to choose.
 	 *
 	 * @param start
+	 *            start of the range
 	 * @param end
+	 *            end of the range
 	 * @param selected
-	 * @return
+	 *            the current selection (may be null)
+	 * @return a list of select options for the integers in the range
 	 */
 	public static List<SelectOption<Integer>> forRange(Integer start, Integer end, Integer selected) {
 		return IntStream.rangeClosed(start, end)

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/SelectOption.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/SelectOption.java
@@ -4,21 +4,37 @@ import java.util.Collection;
 
 /**
  * Used for UI select inputs. Wraps the choice along with its selected status. Value and label is the choice.
- * 
+ *
  * @author lawhead
  *
  * @param <T>
+ *            the type of object wrapped by the option
  */
 public class SelectOption<T> {
 
+	/**
+	 * The object wrapped by the select option.
+	 */
 	protected T choice;
+
+	/**
+	 * The value of the option element's <code>value</code> attribute when rendered to HTML.
+	 */
 	protected String value;
+
+	/**
+	 * The text of the option element when rendered to HTML.
+	 */
 	protected String label;
+
+	/**
+	 * Whether the option is currently selected.
+	 */
 	protected Boolean selected;
 
 	/**
 	 * Constructor. The label and value will be set to choice.toString().
-	 * 
+	 *
 	 * @param choice
 	 *            - lookup list item
 	 * @param selected
@@ -30,10 +46,10 @@ public class SelectOption<T> {
 		this.value = choice.toString();
 		this.selected = choice.equals(selected);
 	}
-	
+
 	/**
 	 * Constructor used for an option in a multi-select.
-	 * 
+	 *
 	 * @param choice
 	 *            - lookup list item
 	 * @param selected
@@ -46,30 +62,68 @@ public class SelectOption<T> {
 		this.selected = selected != null && selected.contains(choice);
 	}
 
+	/**
+	 * Gets the item wrapped by the select option.
+	 *
+	 * @return the select option item
+	 */
 	public T getChoice() {
 		return choice;
 	}
 
+	/**
+	 * Gets the string used as the value of the option tag's <code>value</code> attribute.
+	 *
+	 * @return the option tag value
+	 */
 	public String getValue() {
 		return value;
 	}
 
+	/**
+	 * Sets the string used as the option tag's <code>value</code> attribute.
+	 *
+	 * @param value
+	 *            the option tag value
+	 */
 	public void setValue(String value) {
 		this.value = value;
 	}
 
+	/**
+	 * Gets the string used as the text of the option tag.
+	 *
+	 * @return the option tag label
+	 */
 	public String getLabel() {
 		return label;
 	}
 
+	/**
+	 * Sets the string used as the text of the option tag.
+	 *
+	 * @param label
+	 *            the option tag label
+	 */
 	public void setLabel(String label) {
 		this.label = label;
 	}
 
+	/**
+	 * Whether the item is currently selected.
+	 *
+	 * @return true if selected
+	 */
 	public Boolean getSelected() {
 		return selected;
 	}
 
+	/**
+	 * Sets whether the item is currently selected.
+	 *
+	 * @param selected
+	 *            true if selected
+	 */
 	public void setSelected(Boolean selected) {
 		this.selected = selected;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/utils/ValidationUtils.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/utils/ValidationUtils.java
@@ -23,15 +23,22 @@ import jakarta.validation.Path.Node;
 @Component
 public class ValidationUtils<T> {
 
-	// See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#Basic_validation
+	/**
+	 * Regex used to validate email addresses.
+	 *
+	 * @see <a href=
+	 *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#Basic_validation">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#Basic_validation</a>
+	 */
 	public static final String VALID_EMAIL_REGEX = "^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
 
 	/**
 	 * Get list of {@link FieldError} used in mustache templates.
 	 *
 	 * @param object
+	 *            the bean being validated
 	 * @param validationResult
-	 * @return
+	 *            constraint violations encountered during bean validation
+	 * @return a list of errors suitable for rendering
 	 */
 	public List<FieldError> getErrors(T object, Set<ConstraintViolation<T>> validationResult) {
 		List<FieldError> errors = new ArrayList<>();

--- a/authentication_ui_bootstrap5/pom.xml
+++ b/authentication_ui_bootstrap5/pom.xml
@@ -85,6 +85,9 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>
@@ -94,6 +97,9 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
# Overview

Enable building Javadoc and source jars, and fix all Javadoc errors and warnings reported by Maven.

## Issues

[CIS-3193](https://jirabp.ohsu.edu/browse/CIS-3193)

[X] Added to CHANGELOG.md

## Discussion

Most of the work here was to fix all of the errors and warnings identified when processing the Javadoc. Almost all of the errors were caused by incorrect syntax when using `{@link}` or `@see`, while most warnings were caused by missing field, method, and parameter documentation. This was extremely tedious work, and for that reason I don't expect every change to be reviewed.