### PR TITLE
CIS-3191 GPG Signing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,16 +21,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Java build environmant
+      - name: Set up Java build environment
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Build with Maven
         run: mvn package
-      
+
       - name: Get Version from POM
         id: get-version
         run: |
@@ -39,7 +41,8 @@ jobs:
 
       - name: Publish SNAPSHOT JAR
         if: github.ref == 'refs/heads/main' && contains(env.version, '-SNAPSHOT')
-        run: mvn deploy -DskipTests
+        run: mvn deploy -DskipTests -Pci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,24 +17,27 @@ jobs:
       id: latestrelease
       run: |
           echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/OCTRI/authentication-lib/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-    
+
     - name: confirm release tag
       run: |
           echo ${{ steps.latestrelease.outputs.releasetag }}
-    
+
     - name: tagcheckout
       uses: actions/checkout@v4
       with:
           ref: ${{ steps.latestrelease.outputs.releasetag }}
-    
+
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         server-id: github
-    
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -DskipTests
+      run: mvn deploy -DskipTests -Pci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to jQuery 3.7.1.
 - Upgrade to jQuery UI 1.14.1.
 - Upgrade to Font Awesome 6.7.2.
+- Upgrade to Bootstrap 5.3.7.
+- Upgrade to prettytime 5.0.9.
+- Upgrade to passay 1.6.6.
+- Sign artifacts with GPG. (CIS-3191)
 
 ## [2.1.2] - 2024-12-20
 

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -132,36 +132,5 @@
 			<artifactId>prettytime</artifactId>
 			<version>5.0.9.Final</version>
 		</dependency>
-
 	</dependencies>
-
-	<build>
-		<finalName>authentication_lib</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/authentication_ui_bootstrap5/pom.xml
+++ b/authentication_ui_bootstrap5/pom.xml
@@ -74,35 +74,4 @@
 			<version>1.11.3</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<!-- Build without version number; only affects JAR file in /target. -->
-		<finalName>${project.artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,4 +58,63 @@
 			<url>https://maven.pkg.github.com/OCTRI/authentication-lib</url>
 		</repository>
 	</distributionManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>ci</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.7</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
# Overview

Sign artifacts with GPG as required by Maven Central.

## Issues

[CIS-3191](https://jirabp.ohsu.edu/browse/CIS-3191)

[X] Added to CHANGELOG.md

## Discussion

This PR centralizes build plugin configuration in the parent pom.xml file and adds configuration to sign artifacts with GPG when building in the CI environment. The required GitHub Actions secrets have already been created at the organization level to facilitate use in other repositories ([see here](https://github.com/organizations/OCTRI/settings/secrets/actions)).