### PR TITLE
CIS-3194 Dummy Javadoc for UI Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add "sessionTimeoutSeconds" attribute to the default template advice. (CIS-1329)
 - Add JavaScript to notify users when their session is about to expire. See [UPGRADING.md](UPGRADING.md) for detailed instructions on how to use this feature in your application. (CIS-1329)
 - Add a template fragment with the required `<meta>` tags.
+- Add dummy code to the Bootstrap 5 UI package to ensure that a Javadoc jar is built for Maven Central. (CIS-3194)
 
 ### Changed
 

--- a/authentication_ui_bootstrap5/src/main/java/org/octri/authentication/ui/bootstrap5/DocumentationDummy.java
+++ b/authentication_ui_bootstrap5/src/main/java/org/octri/authentication/ui/bootstrap5/DocumentationDummy.java
@@ -1,0 +1,8 @@
+package org.octri.authentication.ui.bootstrap5;
+
+/**
+ * Dummy class to ensure that a Javadoc jar is generated for the Bootstrap UI package.
+ */
+public class DocumentationDummy {
+
+}

--- a/authentication_ui_bootstrap5/src/main/java/org/octri/authentication/ui/bootstrap5/package-info.java
+++ b/authentication_ui_bootstrap5/src/main/java/org/octri/authentication/ui/bootstrap5/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package for user interface templates styled using Bootstrap 5.x.
+ */
+package org.octri.authentication.ui.bootstrap5;


### PR DESCRIPTION
# Overview

Add dummy code to the UI package to ensure that a Javadoc jar is generated, as required by Maven Central.

## Issues

[CIS-3194](https://jirabp.ohsu.edu/browse/CIS-3194)

[X] Added to CHANGELOG.md
