### PR TITLE
CIS-3194 Publish to Maven Central

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 ---
-name: build
+name: Build
 on:
   push:
     branches:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-java-source:
-    name: build jar file
+    name: Build jar files
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,28 +21,46 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Java build environment
+      - name: Set up Java environment for GitHub Packages
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '17'
-          cache: 'maven'
+          cache: maven
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Build with Maven
+      - name: Build and test
         run: mvn package
 
-      - name: Get Version from POM
+      - name: Get version from POM
         id: get-version
         run: |
           version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$version" >> $GITHUB_ENV
 
-      - name: Publish SNAPSHOT JAR
-        if: github.ref == 'refs/heads/main' && contains(env.version, '-SNAPSHOT')
+      - name: Publish to GitHub Packages
         run: mvn deploy -DskipTests -Pci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
+      - name: Set up Java environment for Maven Central
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish release to Maven Central
+        if: startsWith('refs/tags', github.ref) && !contains(env.version, '-SNAPSHOT')
+        run: mvn deploy -DskipTests -Pci,publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,10 +40,22 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
 
       - name: Publish to GitHub Packages
+        if: github.ref == 'refs/heads/main' || startsWith('refs/tags', github.ref)
         run: mvn deploy -DskipTests -Pci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+  publish:
+    name: Publish to Maven Central
+    needs: build-java-source
+    if: startsWith('refs/tags', github.ref)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Set up Java environment for Maven Central
         uses: actions/setup-java@v4
@@ -56,6 +68,12 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Get version from POM
+        id: get-version
+        run: |
+          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$version" >> $GITHUB_ENV
 
       - name: Publish release to Maven Central
         if: startsWith('refs/tags', github.ref) && !contains(env.version, '-SNAPSHOT')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,43 +1,85 @@
-name: Release draft creation
+name: Create release
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        type: string
+        required: true
+      development_version:
+        description: Next version to set in pom.xml after release. Suffix "-SNAPSHOT" is added automatically.
+        type: string
+        required: true
 
 jobs:
-  build:
-
+  prepare-release:
+    name: Prepare release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: write
+      contents: write
       packages: write
 
     steps:
-    - name: get latest release with tag
-      id: latestrelease
-      run: |
-          echo "::set-output name=releasetag::$(curl -s https://api.github.com/repos/OCTRI/authentication-lib/releases/latest | jq '.tag_name' | sed 's/\"//g')"
-
-    - name: confirm release tag
-      run: |
-          echo ${{ steps.latestrelease.outputs.releasetag }}
-
-    - name: tagcheckout
+    - name: Check out repository
       uses: actions/checkout@v4
-      with:
-          ref: ${{ steps.latestrelease.outputs.releasetag }}
 
-    - name: Set up JDK 17
+    - name: Set up Java build environment
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
         distribution: 'temurin'
-        server-id: github
-        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        java-version: '17'
+        cache: 'maven'
 
-    - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -DskipTests -Pci
+    - name: Set up Git
+      run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+    - name: Update CHANGELOG.md
+      id: update_changelog
+      uses: thomaseizinger/keep-a-changelog-new-release@3.1.0
+      with:
+        tag: v${{ inputs.version }}
+
+    - name: Commit CHANGELOG.md
+      run: |
+        git add CHANGELOG.md
+        git commit -m "Add version ${{ inputs.version }} to CHANGELOG.md"
+
+    - name: Prepare Maven release
+      run: |
+        mvn -B \
+          -Darguments=-DskipTests \
+          -DautoVersionSubmodules=true \
+          -DreleaseVersion=${{ inputs.version }} \
+          -DscmReleaseCommitComment="Release version ${{ inputs.version }}" \
+          -DdevelopmentVersion=${{ inputs.development_version }}-SNAPSHOT \
+          -DscmDevelopmentCommitComment="Next development version - ${{ inputs.development_version }}" \
+          -Dtag=v${{ inputs.version }} \
+          -Dusername=${{ github.actor }} \
+          -Dpassword=${{ secrets.GITHUB_TOKEN }} \
+          release:prepare
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        body: ${{ steps.update_changelog.outputs.release-notes }}
+        draft: false
+        prerelease: false
+        name: ${{ inputs.version }}
+        tag_name: v${{ inputs.version }}
+        generate_release_notes: false
+
+    - name: Build release artifacts
+      run: |
+        gh workflow run build.yaml --ref v${{ inputs.version }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build snapshot artifacts
+      run: |
+        gh workflow run build.yaml --ref main
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to prettytime 5.0.9.
 - Upgrade to passay 1.6.6.
 - Sign artifacts with GPG. (CIS-3191)
+- Publish releases to Maven Central. (CIS-3194)
 
 ## [2.1.2] - 2024-12-20
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,5 +116,22 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>publish</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.8.0</version>
+						<extensions>true</extensions>
+						<configuration>
+							<publishingServerId>central</publishingServerId>
+							<autoPublish>true</autoPublish>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
# Overview

Publish releases to Maven Central.

* Add configuration for the publishing plugin to `pom.xml`
* Update GitHub Actions workflows to release following OCTRI patterns

## Issues

[CIS-3194](https://jirabp.ohsu.edu/browse/CIS-3194)

[X] Added to CHANGELOG.md

## Discussion

The existing release workflow requires manual steps that we haven't historically required (updating pom.xml files, pushing a tag, creating a draft GitHub release). This was unsatisfying and potentially inconsistent, so I figured out how to refactor the release process to follow a workflow that our team is familiar with from Jenkins:

* A user manually enters the release version and the next development version into a form.
* The new version, release date, and compare links are added to `CHANGELOG.md`.
* Maven automatically updates `pom.xml` files, tags the release, and advances the next SNAPSHOT version. Commit messages follow the patterns used in Jenkins.
* A GitHub release is created, with release notes extracted from `CHANGELOG.md`.
* Release artifacts are built and published to GitHub Packages and Maven Central.
* New SNAPSHOT artifacts are built.

I went to the extra effort to figure this process out to prepare for moving our repositories to GitHub Enterprise Cloud. This is the same pattern that our application releases will follow, with the exception that they will also need to build and push a container image (which is a process I already understand well).