### PR TITLE
CIS-3194 Fix Conditional Expression in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
 
       - name: Publish to GitHub Packages
-        if: github.ref == 'refs/heads/main' || startsWith('refs/tags', github.ref)
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         run: mvn deploy -DskipTests -Pci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
   publish:
     name: Publish to Maven Central
     needs: build-java-source
-    if: startsWith('refs/tags', github.ref)
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,7 +76,7 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
 
       - name: Publish release to Maven Central
-        if: startsWith('refs/tags', github.ref) && !contains(env.version, '-SNAPSHOT')
+        if: github.ref_type == 'tag' && !contains(env.version, '-SNAPSHOT')
         run: mvn deploy -DskipTests -Pci,publish
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug in the expression used to detect when a tag is being built. (CIS-3194)
+
 ## [2.2.0] - 2025-07-11
 
 ### Added


### PR DESCRIPTION
# Overview

Detect the type of ref being built using `github.ref_type` instead of using the `startsWith` function. This tests whether the ref is a tag more directly and fixes a bug where the arguments to `startsWith` were reversed.

## Issues

[CIS-3194](https://jirabp.ohsu.edu/browse/CIS-3194)

[X] Added to CHANGELOG.md

## Discussion

No artifacts were built for the latest release. This was caused by reversed arguments in [the `startsWith` function expression](https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions#startswith) used to detect whether a tag is being built. The workflow had the expression `startsWith('refs/tags', github.ref)` when it should have had `startWith(github.ref, 'refs/tags')`. While reviewing the [documentation of the `github` context](https://docs.github.com/en/actions/reference/contexts-reference#github-context) to understand `github.ref`, I found that a `github.ref_type` variable is available, which I think expresses the check being performed more clearly.