### PR TITLE
Descriptive Deployment Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use a more descriptive deployment name when publishing to Maven Central.
+
 ## [2.2.1] - 2025-07-11
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>
+							<deploymentName>AuthLib ${project.version}</deploymentName>
 							<autoPublish>true</autoPublish>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
# Overview

Use a more descriptive deployment name when publishing to Maven Central.

## Issues

[CIS-3194]()

[X] Added to CHANGELOG.md

## Discussion

By default, `central-publishing-maven-plugin` names the upload to Maven Central "Deployment". You can see this in the screenshot below, where the card labeled "Deployment" is the automatic publish of AuthLib 2.2.1.

<img width="2654" height="1500" alt="central sonatype com_publishing_deployments (3)" src="https://github.com/user-attachments/assets/69f1c10f-acd8-4ef1-b4ae-31cd32f4c325" />

I expect that this will get confusing when we start publishing multiple packages, so this PR configures a custom deployment name.
