### PR TITLE
AUTHLIB-161 Deprecate Classes Being Replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use a more descriptive deployment name when publishing to Maven Central.
 - Document release process. (AUTHLIB-156)
+- Deprecate classes replaced by common-lib alternatives (AUTHLIB-161)
 
 ## [2.2.1] - 2025-07-11
 

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -36,11 +36,12 @@
 		<connection>scm:git:https://github.com/OCTRI/authentication-lib.git</connection>
 		<developerConnection>scm:git:https://github.com/OCTRI/authentication-lib.git</developerConnection>
 		<url>https://github.com/OCTRI/authentication-lib/tree/main</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<properties>
 		<java.version>17</java.version>
+		<commonlib.version>1.7.1</commonlib.version>
 	</properties>
 
 	<repositories>
@@ -51,6 +52,11 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.octri.common</groupId>
+			<artifactId>common_lib</artifactId>
+			<version>${commonlib.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AbstractEntity.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/entity/AbstractEntity.java
@@ -14,11 +14,14 @@ import jakarta.persistence.MappedSuperclass;
  * An abstract entity for all other entities to extend. It includes the base {@link #id} field which is
  * auto-incrementing.
  *
- * TODO: Add back in auditing?
+ * @deprecated
+ *             Use {@link org.octri.common.domain.AbstractEntity} from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> instead.
  *
  * @author yateam
  */
 @MappedSuperclass
+@Deprecated(since = "2.3.0", forRemoval = true)
 public abstract class AbstractEntity implements Serializable, Identified {
 
 	private static final long serialVersionUID = 3042616837618435959L;
@@ -59,7 +62,7 @@ public abstract class AbstractEntity implements Serializable, Identified {
 
 	/**
 	 * Sets the entity's ID.
-	 * 
+	 *
 	 * @param id
 	 *            unique identifier value
 	 */

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/EntitySelectOption.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/EntitySelectOption.java
@@ -5,11 +5,16 @@ import java.util.Collection;
 /**
  * Used for UI select inputs. Wraps the choice along with its selected status.
  *
+ * @deprecated
+ *             Use {@link org.octri.common.view.EntitySelectOption} from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> instead.
+ *
  * @author lawhead
  *
  * @param <T>
  *            the type of object wrapped by the option
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public class EntitySelectOption<T extends Identified & Labelled> extends SelectOption<T> {
 
 	/**
@@ -42,7 +47,7 @@ public class EntitySelectOption<T extends Identified & Labelled> extends SelectO
 
 	/**
 	 * Gets the entity's ID
-	 * 
+	 *
 	 * @return the ID value
 	 */
 	public Long getId() {

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumOptionList.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumOptionList.java
@@ -7,14 +7,21 @@ import java.util.stream.StreamSupport;
 /**
  * Used in mustache views for pulldown lists.
  *
+ * @deprecated
+ *             Use equivalent methods of {@link org.octri.common.view.OptionList} from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> class instead.
+ *
  * @author lawhead
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public class EnumOptionList {
 
 	/**
 	 * Given a collection of Enum values and the selected value, provides a list of objects that can be used directly by
 	 * mustachejs for rendering.
 	 *
+	 * @deprecated
+	 *             Use {@link org.octri.common.view.OptionList#fromEnum(Iterable, Enum)} instead.
 	 * @param <T>
 	 *            an enum type
 	 * @param iter

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumSelectOption.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/EnumSelectOption.java
@@ -5,13 +5,17 @@ import java.util.Collection;
 /**
  * Used for UI select inputs. Wraps the choice along with its selected status.
  *
+ *
+ * @deprecated
+ *             Use {@link org.octri.common.view.EnumSelectOption} from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> instead.
+ *
  * @author harrelst
  *
- * @param<T>
- *
- * TODO:
- *               Move into a stand alone library.
+ * @param <T>
+ *            the enum type wrapped by the option
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public class EnumSelectOption<T extends Enum<T> & Labelled> extends SelectOption<T> {
 
 	/**

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/Identified.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/Identified.java
@@ -2,14 +2,21 @@ package org.octri.authentication.server.view;
 
 /**
  * Interface used for identifying an object in the UI.
- * 
+ *
+ * @deprecated
+ *             This interface will be removed along with
+ *             {@link org.octri.authentication.server.security.entity.AbstractEntity}. Consuming applications should use
+ *             {@link org.octri.common.domain.AbstractEntity} and related methods from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> instead.
+ *
  * @author yateam
  *
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public interface Identified {
-	
+
 	/**
-	 * 
+	 *
 	 * @return the identifier for the object
 	 */
 	public abstract Long getId();

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/Labelled.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/Labelled.java
@@ -2,10 +2,15 @@ package org.octri.authentication.server.view;
 
 /**
  * Interface used for labelling an object in the UI.
- * 
+ *
+ * @deprecated
+ *             Use {@link org.octri.common.view.Labelled} from <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI
+ *             common-lib</a> instead.
+ *
  * @author lawhead
  *
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public interface Labelled {
 
 	/**

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/OptionList.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/OptionList.java
@@ -9,16 +9,26 @@ import java.util.stream.StreamSupport;
 /**
  * Used for rendering mustache templates. Helper functions for creating a list of select input options.
  *
+ * @deprecated
+ *             Use {@link org.octri.common.view.OptionList} from
+ *             <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> class instead.
+ *
  * @author lawhead
  * @param <T>
  *            the type of objects in the select list
  *
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public class OptionList<T> {
 
 	/**
 	 * Given a Repository search result of lookups and the selected lookup item, provides a list of objects that can be
 	 * used directly by mustachejs for rendering.
+	 *
+	 * @deprecated
+	 *             Use
+	 *             {@link org.octri.common.view.OptionList#fromSearch(Iterable, org.octri.common.domain.AbstractEntity)}
+	 *             instead.
 	 *
 	 * @param <T>
 	 *            a type with an ID and label
@@ -39,6 +49,9 @@ public class OptionList<T> {
 	 * Used for multi-selects. Given a Repository search result of lookups and a list of selected lookup, provides a
 	 * list of objects that can be used directly by mustachejs for rendering.
 	 *
+	 * @deprecated
+	 *             Use {@link org.octri.common.view.OptionList#multiFromSearch(Iterable, Collection)} instead.
+	 *
 	 * @param <T>
 	 *            a type with an ID and a label
 	 * @param iter
@@ -56,6 +69,9 @@ public class OptionList<T> {
 
 	/**
 	 * Generates a list of integers in the given range from which to choose.
+	 *
+	 * @deprecated
+	 *             Use {@link org.octri.common.view.OptionList#forRange(Integer, Integer, Integer)} instead.
 	 *
 	 * @param start
 	 *            start of the range

--- a/authentication_lib/src/main/java/org/octri/authentication/server/view/SelectOption.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/view/SelectOption.java
@@ -5,11 +5,15 @@ import java.util.Collection;
 /**
  * Used for UI select inputs. Wraps the choice along with its selected status. Value and label is the choice.
  *
+ * @deprecated
+ *             Use the equivalent <a href="https://github.com/OHSU-OCTRI/common-lib">OCTRI common-lib</a> class instead.
+ *
  * @author lawhead
  *
  * @param <T>
  *            the type of object wrapped by the option
  */
+@Deprecated(since = "2.3.0", forRemoval = true)
 public class SelectOption<T> {
 
 	/**


### PR DESCRIPTION
# Overview

Deprecate classes being replaced by equivalents from common-lib. This will help identify application code that needs to changed before upgrading to the next version of AuthLib.

## Issues

[AUTHLIB-161](https://jirabp.ohsu.edu/browse/AUTHLIB-161)

[X] Added to CHANGELOG.md
