### PR TITLE
AUTHLIB-162 Replace Email Address Property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `octri.authentication.account-message-email` to replace deprecated `spring.mail.from` property. (AUTHLIB-162)
+
 ### Changed
 
 - Use a more descriptive deployment name when publishing to Maven Central.

--- a/authentication_lib/src/main/java/org/octri/authentication/config/DeprecationMessages.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/DeprecationMessages.java
@@ -1,0 +1,18 @@
+package org.octri.authentication.config;
+
+/**
+ * Holds reusable deprecation messages.
+ */
+public class DeprecationMessages {
+
+	/**
+	 * Warns about the deprecated <code>octri.authentication.email-dry-run</code> property.
+	 */
+	public static final String EMAIL_DRY_RUN = "Setting octri.authentication.email-dry-run=true is deprecated. Use octri.messaging.email-delivery-strategy=LOG instead.";
+
+	/**
+	 * Warns about the deprecated <code>spring.mail.from</code> property.
+	 */
+	public static final String SPRING_MAIL_FROM = "Setting spring.mail.from is deprecated. Use octri.authentication.account-message-email instead.";
+
+}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/EmailConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/EmailConfiguration.java
@@ -31,7 +31,7 @@ public class EmailConfiguration {
 	 * Gets whether email support is enabled.
 	 *
 	 * @deprecated
-	 *             Use `octri.messaging.enabled` instead.
+	 *             Use <code>octri.messaging.enabled</code> instead.
 	 *
 	 * @return true if email is enabled
 	 */
@@ -53,8 +53,12 @@ public class EmailConfiguration {
 	/**
 	 * Gets the configured from email address.
 	 *
+	 * @deprecated
+	 *             Use <code>octri.authentication.account-message-email</code> instead.
+	 *
 	 * @return the configured from email address
 	 */
+	@DeprecatedConfigurationProperty(since = "2.3.0", reason = "Replaced by octri.authentication.account-message-email", replacement = "octri.authentication.account-message-email")
 	public String getFrom() {
 		return from;
 	}

--- a/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationProperties.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationProperties.java
@@ -17,7 +17,7 @@ public class OctriAuthenticationProperties {
 
 	/**
 	 * Allowed username styles. Valid options are PLAIN (simple username), EMAIL (must be an email address), or MIXED
-	 * (may be either a plain username or an email adress).
+	 * (may be either a plain username or an email address).
 	 */
 	public static enum UsernameStyle {
 		/**
@@ -133,6 +133,11 @@ public class OctriAuthenticationProperties {
 	 * to the application's context path. Only relevant when "octri.authentication.role-style" is "custom".
 	 */
 	private String customRoleScript;
+
+	/**
+	 * Email address that account notification emails should come from.
+	 */
+	private String accountMessageEmail;
 
 	/**
 	 * Gets whether LDAP authentication is enabled.
@@ -351,13 +356,33 @@ public class OctriAuthenticationProperties {
 		this.customRoleScript = customRoleScript;
 	}
 
+	/**
+	 * Gets the email address used to send account notification messages.
+	 *
+	 * @return the configured email address
+	 */
+	public String getAccountMessageEmail() {
+		return accountMessageEmail;
+	}
+
+	/**
+	 * Sets the email address to use when sending account notification messages.
+	 *
+	 * @param accountMessageEmail
+	 *            the email address to use
+	 */
+	public void setAccountMessageEmail(String accountMessageEmail) {
+		this.accountMessageEmail = accountMessageEmail;
+	}
+
 	@Override
 	public String toString() {
 		return "OctriAuthenticationProperties [enableLdap=" + enableLdap + ", enableTableBased=" + enableTableBased
 				+ ", baseUrl=" + baseUrl + ", maxLoginAttempts=" + maxLoginAttempts + ", credentialsExpirationPeriod="
 				+ credentialsExpirationPeriod + ", usernameStyle=" + usernameStyle + ", passwordTokenValidFor="
 				+ passwordTokenValidFor + ", emailRequired=" + emailRequired + ", emailDryRun=" + emailDryRun
-				+ ", roleStyle=" + roleStyle + ", customRoleScript=" + customRoleScript + "]";
+				+ ", roleStyle=" + roleStyle + ", customRoleScript=" + customRoleScript + ", accountMessageEmail="
+				+ accountMessageEmail + "]";
 	}
 
 }

--- a/authentication_lib/src/main/java/org/octri/authentication/server/security/service/EmailNotificationService.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/server/security/service/EmailNotificationService.java
@@ -3,6 +3,7 @@ package org.octri.authentication.server.security.service;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.octri.authentication.config.DeprecationMessages;
 import org.octri.authentication.config.OctriAuthenticationProperties;
 import org.octri.authentication.server.security.AuthenticationUrlHelper;
 import org.octri.authentication.server.security.entity.PasswordResetToken;
@@ -23,7 +24,6 @@ public class EmailNotificationService {
     private static final Log log = LogFactory.getLog(EmailNotificationService.class);
 
     private final String displayName;
-    private final String fromAddress;
     private final OctriAuthenticationProperties authenticationProperties;
     private final AuthenticationUrlHelper urlHelper;
     private final MessageDeliveryService messageDeliveryService;
@@ -44,11 +44,9 @@ public class EmailNotificationService {
      *            password reset token service
      */
     public EmailNotificationService(@Value("${app.displayName}") String displayName,
-            @Value("${spring.mail.from}") String fromAddress, OctriAuthenticationProperties authenticationProperties,
-            AuthenticationUrlHelper urlHelper, MessageDeliveryService messageDeliveryService,
-            PasswordResetTokenService passwordResetTokenService) {
+            OctriAuthenticationProperties authenticationProperties, AuthenticationUrlHelper urlHelper,
+            MessageDeliveryService messageDeliveryService, PasswordResetTokenService passwordResetTokenService) {
         this.displayName = displayName;
-        this.fromAddress = fromAddress;
         this.authenticationProperties = authenticationProperties;
         this.urlHelper = urlHelper;
         this.messageDeliveryService = messageDeliveryService;
@@ -71,6 +69,7 @@ public class EmailNotificationService {
 
         final User user = token.getUser();
         final String resetPath = urlHelper.getPasswordResetUrl(token.getToken());
+        final String fromAddress = authenticationProperties.getAccountMessageEmail();
         String subject;
         String body;
 
@@ -102,6 +101,7 @@ public class EmailNotificationService {
         PasswordResetToken passwordResetToken = passwordResetTokenService.findByToken(token);
         Assert.notNull(passwordResetToken, "Could not find a user for the provided token");
 
+        final String fromAddress = authenticationProperties.getAccountMessageEmail();
         final String userEmail = passwordResetToken.getUser().getEmail();
 
         final String subject = "Your " + displayName + " password was reset";
@@ -127,9 +127,8 @@ public class EmailNotificationService {
     }
 
     private static void logDryRunEmail(String fromAddress, String toAddress, String subject, String body) {
-        final String deprecationMessage = "Setting octri.authentication.email-dry-run=true is deprecated. Use octri.messaging.email-delivery-strategy=LOG instead.";
         final String format = "DRY RUN, would have sent email to %s from %s with subject \"%s\" and contents \"%s\"";
-        log.warn(deprecationMessage);
+        log.warn(DeprecationMessages.EMAIL_DRY_RUN);
         log.info(String.format(format, String.join(", ", toAddress), fromAddress, subject,
                 body));
     }

--- a/authentication_lib/src/test/java/org/octri/authentication/server/security/service/EmailNotificationServiceTest.java
+++ b/authentication_lib/src/test/java/org/octri/authentication/server/security/service/EmailNotificationServiceTest.java
@@ -64,8 +64,9 @@ public class EmailNotificationServiceTest {
 		passwordResetToken.setUser(user);
 		passwordResetToken.setToken(RESET_TOKEN);
 		authenticationProperties = new OctriAuthenticationProperties();
-		emailNotificationService = new EmailNotificationService(DISPLAY_NAME, SENDER_EMAIL,
-				authenticationProperties, urlHelper, messageDeliveryService, passwordResetTokenService);
+		authenticationProperties.setAccountMessageEmail(SENDER_EMAIL);
+		emailNotificationService = new EmailNotificationService(DISPLAY_NAME, authenticationProperties, urlHelper,
+				messageDeliveryService, passwordResetTokenService);
 	}
 
 	private User user() {


### PR DESCRIPTION
# Overview

Replace the `spring.mail.from` property with a better-named property in the main authentication properties class.

## Issues

[AUTHLIB-162](https://jirabp.ohsu.edu/browse/AUTHLIB-162)

[X] Added to CHANGELOG.md

## Discussion

I realized that like the `spring.mail.enabled` property, `spring.mail.from` was another property that we added to the `spring.mail` namespace. Because I intend to remove the class that holds these properties, I needed another place to put the email address to use when sending account-related email.