### PR TITLE
CIS-3368 Publish SNAPSHOT Artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
   publish:
     name: Publish to Maven Central
     needs: build-java-source
-    if: github.ref_type == 'tag'
+    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,14 +69,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Get version from POM
-        id: get-version
-        run: |
-          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$version" >> $GITHUB_ENV
-
       - name: Publish release to Maven Central
-        if: github.ref_type == 'tag' && !contains(env.version, '-SNAPSHOT')
         run: mvn deploy -DskipTests -Pci,publish
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade to messaging-lib 0.2.0 for email subject prefix support. (CIS-3351)
 - Use the value of `octri.messaging.default-sender-address` property if `octri.authentication.account-message-email` is not set.
+- Publish -SNAPSHOT releases to Maven Central. (CIS-3368)
 
 ## [3.0.0] - 2025-09-29
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
 							<publishingServerId>central</publishingServerId>
 							<deploymentName>AuthLib ${project.version}</deploymentName>
 							<autoPublish>true</autoPublish>
+							<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
# Overview

Update the GitHub Actions build workflow to publish -SNAPSHOT artifacts to Maven Central, in addition to GitHub Packages.

## Issues

[CIS-3368](https://jirabp.ohsu.edu/browse/CIS-3368)

[X] Added to CHANGELOG.md
