### PR TITLE
AUTHLIB-172 Fix Bug in RequestUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extract client IP address correctly when `X-Forwarded-For` header contains a list of IP addresses. (AUTHLIB-172)
+
 ## [4.1.0] - 2026-04-17
 
 ### Added

--- a/authentication_lib/src/main/java/org/octri/authentication/RequestUtils.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/RequestUtils.java
@@ -1,5 +1,7 @@
 package org.octri.authentication;
 
+import java.util.List;
+
 import org.springframework.util.Assert;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,23 +30,28 @@ public final class RequestUtils {
 	 */
 	public static String getClientIpAddr(HttpServletRequest request) {
 		Assert.notNull(request, "request may not be null");
+		List<String> headerNames = List.of("X-Forwarded-For", "Proxy-Client-IP", "WL-Proxy-Client-IP", "HTTP_CLIENT_IP",
+				"HTTP_X_FORWARDED_FOR");
+		String ip = null;
 
-		String ip = request.getHeader("X-Forwarded-For");
-		if (ip == null || ip.length() == 0 || UNKNOWN.equalsIgnoreCase(ip)) {
-			ip = request.getHeader("Proxy-Client-IP");
+		// check common proxy headers
+		for (String headerName : headerNames) {
+			ip = request.getHeader(headerName);
+			if (ip != null && ip.length() > 0 && !UNKNOWN.equalsIgnoreCase(ip)) {
+				break;
+			}
 		}
-		if (ip == null || ip.length() == 0 || UNKNOWN.equalsIgnoreCase(ip)) {
-			ip = request.getHeader("WL-Proxy-Client-IP");
-		}
-		if (ip == null || ip.length() == 0 || UNKNOWN.equalsIgnoreCase(ip)) {
-			ip = request.getHeader("HTTP_CLIENT_IP");
-		}
-		if (ip == null || ip.length() == 0 || UNKNOWN.equalsIgnoreCase(ip)) {
-			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
-		}
+
+		// IP not found in headers; default to getRemoteAddr()
 		if (ip == null || ip.length() == 0 || UNKNOWN.equalsIgnoreCase(ip)) {
 			ip = request.getRemoteAddr();
 		}
+
+		// extract the client IP when the header contains a chain of IPs
+		if (ip.indexOf(",") != -1) {
+			ip = ip.substring(0, ip.indexOf(",")).trim();
+		}
+
 		return ip;
 	}
 }

--- a/authentication_lib/src/test/java/org/octri/authentication/RequestUtilsTest.java
+++ b/authentication_lib/src/test/java/org/octri/authentication/RequestUtilsTest.java
@@ -1,0 +1,126 @@
+package org.octri.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestUtilsTest {
+
+	private static final String IP = "192.168.1.100";
+
+	@Mock
+	private HttpServletRequest mockRequest;
+
+	@Test
+	public void testNullRequestThrowsException() {
+		assertThrows(IllegalArgumentException.class, () -> RequestUtils.getClientIpAddr(null),
+				"Null request should throw IllegalArgumentException");
+	}
+
+	@Test
+	public void testReturnsXForwardedForHeader() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest), "Should return X-Forwarded-For header value");
+	}
+
+	@Test
+	public void testReturnsProxyClientIpHeader() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest), "Should return Proxy-Client-IP header value");
+	}
+
+	@Test
+	public void testReturnsWlProxyClientIpHeader() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("WL-Proxy-Client-IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest), "Should return WL-Proxy-Client-IP header value");
+	}
+
+	@Test
+	public void testReturnsHttpClientIpHeader() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("HTTP_CLIENT_IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest), "Should return HTTP_CLIENT_IP header value");
+	}
+
+	@Test
+	public void testReturnsHttpXForwardedForHeader() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("HTTP_CLIENT_IP")).thenReturn(null);
+		when(mockRequest.getHeader("HTTP_X_FORWARDED_FOR")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest), "Should return HTTP_X_FORWARDED_FOR header value");
+	}
+
+	@Test
+	public void testFallsBackToRemoteAddr() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(null);
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+		when(mockRequest.getHeader("HTTP_CLIENT_IP")).thenReturn(null);
+		when(mockRequest.getHeader("HTTP_X_FORWARDED_FOR")).thenReturn(null);
+		when(mockRequest.getRemoteAddr()).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest),
+				"Should fall back to getRemoteAddr() when no headers are set");
+	}
+
+	@Test
+	public void testUnknownXForwardedForFallsThrough() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn("unknown");
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest),
+				"'unknown' X-Forwarded-For should fall through to Proxy-Client-IP");
+	}
+
+	@Test
+	public void testEmptyXForwardedForFallsThrough() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn("");
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest),
+				"Empty X-Forwarded-For should fall through to Proxy-Client-IP");
+	}
+
+	@Test
+	public void testUnknownCaseInsensitive() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn("UNKNOWN");
+		when(mockRequest.getHeader("Proxy-Client-IP")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest),
+				"'unknown' check should be case-insensitive");
+	}
+
+	@Test
+	public void testXForwardedForTakesPriorityOverOthers() {
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(IP);
+		assertEquals(IP, RequestUtils.getClientIpAddr(mockRequest),
+				"X-Forwarded-For should take priority over all other headers");
+	}
+
+	@Test
+	public void testXForwardedForIpListReturnsFirstIpAddress() {
+		var ipV4List = "203.0.113.10, 10.0.0.5, 172.16.0.2";
+		var expectedIpV4 = "203.0.113.10";
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(ipV4List);
+		assertEquals(expectedIpV4, RequestUtils.getClientIpAddr(mockRequest),
+				"Should return the first IP address in a comma-separated list of addresses");
+
+		var mixedIpList = "2603:3004:88c:0:c00a:6668:b90e:c1,139.60.24.135";
+		var expectedIpV6 = "2603:3004:88c:0:c00a:6668:b90e:c1";
+		when(mockRequest.getHeader("X-Forwarded-For")).thenReturn(mixedIpList);
+		assertEquals(expectedIpV6, RequestUtils.getClientIpAddr(mockRequest),
+				"Should return the first IP address in a list of mixed IPv4 and IPv6 addresses");
+	}
+
+}


### PR DESCRIPTION
# Overview

Properly extract the client IP address from the `X-Forwarded-For` header when the header value is a list of IP addresses. Fixes an issue where the entire chain was being returned, overflowing the database column.

## Issues

AUTHLIB-172

[X] Added to CHANGELOG.md
