### PR TITLE
CIS-3739 Upgrade messaging-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps org.octri.messaging:messaging_lib from 0.2.1 to 0.2.2
 - Bumps org.octri.common:common_lib from 2.1.0 to 2.1.1
 - Bumps org.springframework.boot:spring-boot-starter-parent from 3.5.15 to 3.5.16
+- Bumps org.octri.messaging:messaging_lib from 0.2.2 to 0.2.3
 
 ## [4.2.0] - 2026-05-29
 

--- a/authentication_lib/pom.xml
+++ b/authentication_lib/pom.xml
@@ -42,7 +42,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<commonlib.version>2.1.1</commonlib.version>
-		<messaginglib.version>0.2.2</messaginglib.version>
+		<messaginglib.version>0.2.3</messaginglib.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
# Overview

Upgrade the messaging-lib dependency to 0.2.3 (which updates the Twilio transitive dependency).

## Issues

[CIS-3739](https://jirabp.ohsu.edu/browse/CIS-3739)

[x] Added to CHANGELOG.md

## Discussion

Related to [notification-lib #48](https://github.com/OHSU-OCTRI/notification-lib/pull/48), which upgrades the same dependency in notification-lib. Without upgrading the dependency in both packages, downstream projects may resolve an unexpected version of the transitive Twilio dependency.